### PR TITLE
Define paths to Asssemblies and DataSets for use from BHoM_Installer

### DIFF
--- a/InstallerCore/InstallerCore.wixproj
+++ b/InstallerCore/InstallerCore.wixproj
@@ -13,16 +13,20 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
     <OutputPath>bin\$(Configuration)\</OutputPath>
     <IntermediateOutputPath>obj\$(Configuration)\</IntermediateOutputPath>
-    <DefineConstants>Debug;DataDir=DataSets;FilesDir=Assemblies;</DefineConstants>
+    <DefineConstants>Debug;DataDir=..\..\BHoM_Installer\InstallerCore\DataSets;FilesDir=..\..\BHoM_Installer\InstallerCore\Assemblies;</DefineConstants>
+    <VerboseOutput>False</VerboseOutput>
+    <LibBindFiles>False</LibBindFiles>
+    <SuppressAllWarnings>False</SuppressAllWarnings>
+    <Pedantic>False</Pedantic>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
     <OutputPath>bin\$(Configuration)\</OutputPath>
     <IntermediateOutputPath>obj\$(Configuration)\</IntermediateOutputPath>
     <WixVariables>
     </WixVariables>
-    <DefineConstants>DataDir=DataSets;FilesDir=Assemblies;</DefineConstants>
+    <DefineConstants>DataDir=..\..\BHoM_Installer\InstallerCore\DataSets;FilesDir=..\..\BHoM_Installer\InstallerCore\Assemblies;</DefineConstants>
     <SuppressAllWarnings>False</SuppressAllWarnings>
-    <Pedantic>True</Pedantic>
+    <Pedantic>False</Pedantic>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Components.wxs" />


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #3 

Defines the path variables in the InstallerCore wixlib to a path relative to where it is being included since otherwise the files cannot be found

### Test files
<!-- Link to test files to validate the prop osed changes -->
Clone clean and try to build, should produce an installer correctly

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->