### PR TITLE
Build off tags if doing beta installers

### DIFF
--- a/BuildSolution.ps1
+++ b/BuildSolution.ps1
@@ -21,5 +21,48 @@ If ($env:PatchVersion) {
   $patchVersion = $env:PatchVersion
 }
 
+If($releaseType -eq "beta")
+{
+	# Try and checkout tags
+	
+	$version = $ENV:Version
+
+	$cwd = Get-Location
+
+	Write-Output("Changing into repo directory")
+	Set-Location $ENV:BUILD_SOURCESDIRECTORY\BHoM_Installer
+
+	# Update repo to get latest tags
+	git fetch
+	$tags = git tag -l
+	$repoTags = $tags.split(" ")
+	$tag = ""
+
+	For ($i = $repoTags.Length - 1; $i -ge 0; $i--)
+	{
+    	$splitTag = $repoTags[$i].split(".")
+    	If(($splitTag[0] + "." + $splitTag[1]) -eq $version)
+    	{
+    		If($splitTag[3] -le $patchVersion)
+    		{
+    			$tag = $repoTags[$i]
+    			break
+    		}
+    	}
+    }
+
+    If($tag -eq "")
+    {
+    	Write-Output("A suitable Tag for " + $version + ".B." + $patchVersion + " could not be found, staying on master")
+    }
+    Else
+    {
+		Write-Output ("Checking out at tag " + $tag)
+		git checkout -q tags/$tag
+	}
+	
+	Write-Output ("Changing back directory location")
+	Set-Location $cwd
+}
 
 & $msbuildPath -nologo /verbosity:minimal /p:RunWixToolsOutOfProc=true /p:DeployOnBuild=true /p:ReleaseType=$releaseType /p:PatchVersion=$patchVersion /p:WebPublishMethod=Package /p:PackageAsSingleFile=true /p:SkipInvalidConfigurations=true

--- a/CloneAndBuildRepo.ps1
+++ b/CloneAndBuildRepo.ps1
@@ -8,9 +8,55 @@ $repo = $parts[1]
 
 $slnPath = "$ENV:BUILD_SOURCESDIRECTORY\$repo\$repo.sln"
 
+$releaseType = $ENV:ReleaseType
+$version = $ENV:Version
+$patch = $ENV:PatchVersion
+
 # **** Cloning Repo ****
 Write-Output ("Cloning " + $repo + " to " + $ENV:BUILD_SOURCESDIRECTORY + "\" + $repo)
 git clone -q --branch=master https://github.com/$org/$repo.git $ENV:BUILD_SOURCESDIRECTORY\$repo
+
+If($releaseType -eq "beta")
+{
+	# Try and checkout tags
+
+	$cwd = Get-Location
+
+	Write-Output("Changing into repo directory")
+	Set-Location $ENV:BUILD_SOURCESDIRECTORY\$repo
+
+	# Update repo to get latest tags
+	git fetch
+	$tags = git tag -l
+	$repoTags = $tags.split(" ")
+	$tag = ""
+
+	For ($i = $repoTags.Length - 1; $i -ge 0; $i--)
+	{
+    	$splitTag = $repoTags[$i].split(".")
+    	If(($splitTag[0] + "." + $splitTag[1]) -eq $version)
+    	{
+    		If($splitTag[3] -le $patch)
+    		{
+    			$tag = $repoTags[$i]
+    			break
+    		}
+    	}
+    }
+
+    If($tag -eq "")
+    {
+    	Write-Output("A suitable Tag for " + $version + ".B." + $patch + " could not be found, staying on master")
+    }
+    Else
+    {
+		Write-Output ("Checking out at tag " + $tag)
+		git checkout -q tags/$tag
+	}
+	
+	Write-Output ("Changing back directory location")
+	Set-Location $cwd
+}
 
 # **** Restore NuGet ****
 Write-Output ("Restoring NuGet packages for " + $repo)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -38,6 +38,10 @@ steps:
   displayName: 'Clone and Build All Required Repos'
   inputs:
     filePath: 'CloneAndBuildAllRequiredRepos.ps1'
+  env:
+    ReleaseType: $(ReleaseType)
+    PatchVersion: $(PatchVersion)
+    Version: $(Version)
 
 - task: NuGetCommand@2
   displayName: 'Restore NuGets for Primary Solution'
@@ -57,6 +61,7 @@ steps:
   env:
     ReleaseType: $(ReleaseType)
     PatchVersion: $(PatchVersion)
+    Version: $(Version)
   inputs:
     filePath: 'BuildSolution.ps1'
 

--- a/include.txt
+++ b/include.txt
@@ -8,4 +8,3 @@ BHoM/Rhinoceros_Toolkit
 BHoM/Robot_Toolkit
 BHoM/TAS_Toolkit
 BHoM/XML_Toolkit
-


### PR DESCRIPTION
Fixes #11 

Set the variables to be what we need them to be and queue a build.

**Version must contain the `v` - e.g. `v2.4` not `2.4`**

Alpha installer builds should be unaffected and build off `master` as usual.

Beta installer builds will default to `master` if a suitable tag is unavailable. The code for finding a suitable tag basically tries to find the first tag who's patch number is less than or equal to the current patch (starting with the latest tag) to ensure the latest code available for beta is included and built against.