### PR TITLE
Clean up BHoM directories completely on install/remove

### DIFF
--- a/InstallerCore/Components.wxs
+++ b/InstallerCore/Components.wxs
@@ -53,6 +53,8 @@
         <File Source="..\..\Dynamo_Toolkit\pkg.json">
           <CopyFile Id="CpyDynamoPkg" DestinationDirectory="DYNAMOCOREBHOMDIR" />
         </File>
+        <util:RemoveFolderEx On="both" Property="DYNAMOCOREBHOMDIR" />
+        <util:RemoveFolderEx On="both" Property="DYNAMOREVITBHOMDIR" />
       </Component>
     </ComponentGroup>
 

--- a/InstallerCore/Components.wxs
+++ b/InstallerCore/Components.wxs
@@ -56,5 +56,14 @@
       </Component>
     </ComponentGroup>
 
+    <ComponentGroup Id="Core" Directory="INSTALLFOLDER">
+      <Component Id="CleanExisting">
+        <RegistryKey Root="HKCU" Key="Software\BHoM">
+          <RegistryValue Name="Installer" Type="integer" Value="1"></RegistryValue>
+        </RegistryKey>
+        <util:RemoveFolderEx On="both" Property="INSTALLFOLDER" />
+      </Component>
+    </ComponentGroup>
+
 	</Fragment>
 </Wix>

--- a/InstallerCore/Features.wxs
+++ b/InstallerCore/Features.wxs
@@ -19,6 +19,7 @@
       <Feature Id="BHoM" Title="BHoM Core" Level="1">
         <ComponentGroupRef Id="ASSEMBLIES" />
         <ComponentGroupRef Id="DATA" />
+        <ComponentGroupRef Id="Core" />
       </Feature>
 
       <Feature Id="ExcelFeature" Title="Excel Plugin" Level="1">


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #22 

<!-- Add short description of what has been fixed -->
Cleans up `%APPDATA%\BHoM`, `%APPDATA%\Dynamo\Dynamo Revit\1.3\packages\BHoM` and `%APPDATA%\Dynamo\Dynamo Core\1.3\packages\BHoM` on installation and removal (includes repair/change/upgrade flows too)

### Test files
<!-- Link to test files to validate the proposed changes -->
Create files in the aforementioned directories, run installer, see that the files are removed and only a fresh installation (or nothing if you uninstall) remains.

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->

### Additional comments
<!-- As required -->