### PR TITLE
Add ClimateEmergency_Toolkit to installer

### DIFF
--- a/include.txt
+++ b/include.txt
@@ -1,3 +1,4 @@
+BHoM/ClimateEmergency_Toolkit
 BHoM/ETABS_Toolkit
 BHoM/GSA_Toolkit
 BHoM/Lusas_Toolkit


### PR DESCRIPTION
### Issues addressed by this PR
Fixes #24 

### Test files
Run installer and check methods from the ClimateEmergency engine appear in the UIs.


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
This should have on conflicts with the existing PR at this time.