### PR TITLE
Include HTTP_Toolkit into the installer

### DIFF
--- a/include.txt
+++ b/include.txt
@@ -1,6 +1,7 @@
 BHoM/ClimateEmergency_Toolkit
 BHoM/ETABS_Toolkit
 BHoM/GSA_Toolkit
+BHoM/HTTP_Toolkit
 BHoM/Lusas_Toolkit
 BHoM/Mongo_Toolkit
 BHoM/RAM_Toolkit


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #26 
<!-- Add short description of what has been fixed -->

### Questions
<!-- As required -->

> The toolkit has a codeowners file outlining who is responsible for which parts of the code - this can be a global codeowners file with people taking responsibility for the whole toolkit, or it can be split by project/folder for multi-disciplinary toolkits
> Each toolkit should have a minimum of two codeowners to ensure there is redundancy for holidays, sickness, etc.

Does this mean that I should I add a CODEOWNER file as well? 


