### PR TITLE
Make assemblies not keypaths so they always overwrite

### DIFF
--- a/InstallerCore/assemblies.xslt
+++ b/InstallerCore/assemblies.xslt
@@ -18,6 +18,9 @@
   <xsl:template match='wix:Wix/wix:Fragment/wix:ComponentGroup/wix:Component[@Directory="ASSEMBLIESDIR"]/wix:File'>
     <xsl:copy>
       <xsl:apply-templates select="@*"/>
+      <xsl:attribute name="KeyPath">
+        <xsl:text>no</xsl:text>
+      </xsl:attribute>
       <xsl:element name="wix:CopyFile">
         <xsl:attribute name="Id">
           <xsl:text>CpyDYNC13__</xsl:text>


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #48 

Makes all assembly files not key paths so that they are always installed even if they were present on the filesystem beforehand. This is necessary because the decision as to whether to install the file given if they are on the disk already or not is taken prior to the deletion of all files in the directory.

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->