### PR TITLE
Add alternate configurations for Lusas_Toolkit builds

### DIFF
--- a/altConfigs.txt
+++ b/altConfigs.txt
@@ -3,3 +3,5 @@ BHoM/Revit_Toolkit/Release2019
 BHoM/Revit_Toolkit/Release2020
 BHoM/ETABS_Toolkit/Release16
 BHoM/ETABS_Toolkit/Release17
+BHoM/Lusas_Toolkit/Release17
+BHoM/Lusas_Toolkit/Release18


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

 ### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->
https://github.com/BHoM/Lusas_Toolkit/pull/253

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #50 

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
https://burohappold.sharepoint.com/:f:/s/BHoM/EnWHMty88w5PiJ0nLK_qJ-YBNLPTK9BFw-z5UuPo__IWRg?e=jhlHIN

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->
Julia if you could please run the installer in the link above and test Lusas 170.
@StephennipBH if you could please run the installer in the link above and test Lusas 180.

All the booleans are grouped on the far left, and should let you test:
- Push a variety of BHoMObjects to Lusas
- Pull a variety of BHoMObjects from Lusas
- Pull results from Lusas

**Note** You will need to modify the flexural mesh in Lusas once it has been pushed (I just edit one attribute and apply them to the TopChord and BottomChord groups). This is because it defaults to a Thick Cross Section Beam, when the element type should be a Thick Beam. This will be [fixed in this PR](https://github.com/BHoM/Lusas_Toolkit/pull/251). Once you solve the model you should be able to pull results.

Any questions let me know.