### PR TITLE
Resolving unintuitive menu if reinstalling

### DIFF
--- a/InstallerCore/InstallerCore.wixproj
+++ b/InstallerCore/InstallerCore.wixproj
@@ -35,6 +35,7 @@
     <Compile Include="Features.wxs" />
     <Compile Include="UI\BHoMInstallerUI.wxs" />
     <Compile Include="UI\BHoMLicenseAgreementDlg.wxs" />
+    <Compile Include="UI\BHoMMaintenanceTypeDlg.wxs" />
     <Compile Include="UI\BHoMWelcomeDlg.wxs" />
   </ItemGroup>
   <ItemGroup>

--- a/InstallerCore/UI/BHoMInstallerUI.wxs
+++ b/InstallerCore/UI/BHoMInstallerUI.wxs
@@ -31,15 +31,14 @@
       <Publish Dialog="CustomizeDlg" Control="Next" Event="NewDialog" Value="VerifyReadyDlg" Order="2">1</Publish>
 
       <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="CustomizeDlg" Order="2">NOT Installed OR WixUI_InstallMode = "Change"</Publish>
-      <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="MaintenanceTypeDlg" Order="4">WixUI_InstallMode = "Repair" OR WixUI_InstallMode = "Remove"</Publish>
+      <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="BHoMMaintenanceTypeDlg" Order="4">WixUI_InstallMode = "Repair" OR WixUI_InstallMode = "Remove"</Publish>
       <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="BHoMWelcomeDlg" Order="2">WixUI_InstallMode = "Update"</Publish>
 
-      <Publish Dialog="MaintenanceWelcomeDlg" Control="Next" Event="NewDialog" Value="MaintenanceTypeDlg">1</Publish>
+      <Publish Dialog="MaintenanceWelcomeDlg" Control="Next" Event="NewDialog" Value="BHoMMaintenanceTypeDlg">1</Publish>
 
-      <Publish Dialog="MaintenanceTypeDlg" Control="RepairButton" Event="NewDialog" Value="VerifyReadyDlg">1</Publish>
-      <Publish Dialog="MaintenanceTypeDlg" Control="ChangeButton" Event="NewDialog" Value="CustomizeDlg">1</Publish>
-      <Publish Dialog="MaintenanceTypeDlg" Control="RemoveButton" Event="NewDialog" Value="VerifyReadyDlg">1</Publish>
-      <Publish Dialog="MaintenanceTypeDlg" Control="Back" Event="NewDialog" Value="MaintenanceWelcomeDlg">1</Publish>
+      <Publish Dialog="BHoMMaintenanceTypeDlg" Control="RepairButton" Event="NewDialog" Value="CustomizeDlg">1</Publish>
+      <Publish Dialog="BHoMMaintenanceTypeDlg" Control="RemoveButton" Event="NewDialog" Value="VerifyReadyDlg">1</Publish>
+      <Publish Dialog="BHoMMaintenanceTypeDlg" Control="Back" Event="NewDialog" Value="MaintenanceWelcomeDlg">1</Publish>
     </UI>
 	</Fragment>
 </Wix>

--- a/InstallerCore/UI/BHoMInstallerUI.wxs
+++ b/InstallerCore/UI/BHoMInstallerUI.wxs
@@ -25,18 +25,15 @@
       <Publish Dialog="BHoMWelcomeDlg" Control="Next" Event="NewDialog" Value="VerifyReadyDlg">Installed AND PATCH</Publish>
 
       <Publish Dialog="BHoMLicenseAgreementDlg" Control="Back" Event="NewDialog" Value="BHoMWelcomeDlg">1</Publish>
-      <Publish Dialog="BHoMLicenseAgreementDlg" Control="Next" Event="NewDialog" Value="CustomizeDlg" Order="2">1</Publish>
+      <Publish Dialog="BHoMLicenseAgreementDlg" Control="Next" Event="NewDialog" Value="VerifyReadyDlg" Order="2">1</Publish>
 
-      <Publish Dialog="CustomizeDlg" Control="Back" Event="NewDialog" Value="BHoMLicenseAgreementDlg">1</Publish>
-      <Publish Dialog="CustomizeDlg" Control="Next" Event="NewDialog" Value="VerifyReadyDlg" Order="2">1</Publish>
-
-      <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="CustomizeDlg" Order="2">NOT Installed OR WixUI_InstallMode = "Change"</Publish>
+      <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="BHoMLicenseAgreementDlg" Order="2">NOT Installed OR WixUI_InstallMode = "Change"</Publish>
       <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="BHoMMaintenanceTypeDlg" Order="4">WixUI_InstallMode = "Repair" OR WixUI_InstallMode = "Remove"</Publish>
       <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="BHoMWelcomeDlg" Order="2">WixUI_InstallMode = "Update"</Publish>
 
       <Publish Dialog="MaintenanceWelcomeDlg" Control="Next" Event="NewDialog" Value="BHoMMaintenanceTypeDlg">1</Publish>
 
-      <Publish Dialog="BHoMMaintenanceTypeDlg" Control="RepairButton" Event="NewDialog" Value="CustomizeDlg">1</Publish>
+      <Publish Dialog="BHoMMaintenanceTypeDlg" Control="RepairButton" Event="NewDialog" Value="VerifyReadyDlg">1</Publish>
       <Publish Dialog="BHoMMaintenanceTypeDlg" Control="RemoveButton" Event="NewDialog" Value="VerifyReadyDlg">1</Publish>
       <Publish Dialog="BHoMMaintenanceTypeDlg" Control="Back" Event="NewDialog" Value="MaintenanceWelcomeDlg">1</Publish>
     </UI>

--- a/InstallerCore/UI/BHoMMaintenanceTypeDlg.wxs
+++ b/InstallerCore/UI/BHoMMaintenanceTypeDlg.wxs
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
+    <Fragment>
+        <UI>
+            <Dialog Id="BHoMMaintenanceTypeDlg" Width="370" Height="270" Title="!(loc.MaintenanceTypeDlg_Title)">
+                <Control Id="RepairButton" Type="PushButton" X="40" Y="65" Width="80" Height="17" ToolTip="!(loc.MaintenanceTypeDlgRepairButtonTooltip)" Text="!(loc.MaintenanceTypeDlgRepairButton)">
+                    <Publish Property="WixUI_InstallMode" Value="Repair">1</Publish>
+                    <Condition Action="disable">ARPNOREPAIR</Condition>
+                </Control>
+                <Control Id="RepairText" Type="Text" X="60" Y="85" Width="280" Height="30" Text="!(loc.MaintenanceTypeDlgRepairText)">
+                    <Condition Action="hide">ARPNOREPAIR</Condition>
+                </Control>
+                <Control Id="RepairDisabledText" Type="Text" X="60" Y="85" Width="280" Height="30" NoPrefix="yes" Text="!(loc.MaintenanceTypeDlgRepairDisabledText)" Hidden="yes">
+                    <Condition Action="show">ARPNOREPAIR</Condition>
+                </Control>
+                <Control Id="RemoveButton" Type="PushButton" X="40" Y="118" Width="80" Height="17" ToolTip="!(loc.MaintenanceTypeDlgRemoveButtonTooltip)" Text="!(loc.MaintenanceTypeDlgRemoveButton)">
+                    <Publish Property="WixUI_InstallMode" Value="Remove">1</Publish>
+                    <Condition Action="disable">ARPNOREMOVE</Condition>
+                </Control>
+                <Control Id="RemoveText" Type="Text" X="60" Y="138" Width="280" Height="20" NoPrefix="yes" Text="!(loc.MaintenanceTypeDlgRemoveText)">
+                    <Condition Action="hide">ARPNOREMOVE</Condition>
+                </Control>
+                <Control Id="RemoveDisabledText" Type="Text" X="60" Y="138" Width="280" Height="20" NoPrefix="yes" Text="!(loc.MaintenanceTypeDlgRemoveDisabledText)" Hidden="yes">
+                    <Condition Action="show">ARPNOREMOVE</Condition>
+                </Control>
+                <Control Id="Back" Type="PushButton" X="180" Y="243" Width="56" Height="17" Text="!(loc.WixUIBack)" />
+                <Control Id="Next" Type="PushButton" X="236" Y="243" Width="56" Height="17" Disabled="yes" Text="!(loc.WixUINext)" />
+                <Control Id="Cancel" Type="PushButton" X="304" Y="243" Width="56" Height="17" Cancel="yes" Text="!(loc.WixUICancel)">
+                    <Publish Event="SpawnDialog" Value="CancelDlg">1</Publish>
+                </Control>
+                <Control Id="BannerBitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="44" TabSkip="no" Text="!(loc.MaintenanceTypeDlgBannerBitmap)" />
+                <Control Id="BannerLine" Type="Line" X="0" Y="44" Width="370" Height="0" />
+                <Control Id="BottomLine" Type="Line" X="0" Y="234" Width="370" Height="0" />
+                <Control Id="Title" Type="Text" X="15" Y="6" Width="340" Height="15" Transparent="yes" NoPrefix="yes" Text="!(loc.MaintenanceTypeDlgTitle)" />
+                <Control Id="Description" Type="Text" X="25" Y="23" Width="340" Height="20" Transparent="yes" NoPrefix="yes" Text="!(loc.MaintenanceTypeDlgDescription)" />
+            </Dialog>
+        </UI>
+    </Fragment>
+</Wix>

--- a/InstallerCore/loc/en-us.wxl
+++ b/InstallerCore/loc/en-us.wxl
@@ -11,8 +11,10 @@ Copyright (c) [CopyrightHolder]
 &lt;<![CDATA[<a href="]]>[CopyrightUrl]<![CDATA[">]]>[CopyrightUrl]<![CDATA[</a>]]>&gt;</String>
   <String Id="MaintenanceTypeDlgTitle">{\WixUI_Font_Title}Reinstall or remove BHoM installation</String>
   <String Id="MaintenanceTypeDlgRepairButton">Reinstall</String>
+  <String Id="MaintenanceTypeDlgRepairButtonTooltip">Reinstall BHoM</String>
   <String Id="MaintenanceTypeDlgRepairText">Select this option to simply reinstall this version of the BHoM on your machine.</String>
   <String Id="MaintenanceTypeDlgRemoveButton">Remove</String>
+  <String Id="MaintenanceTypeDlgRemoveButtonTooltip">Remove BHoM</String>
   <String Id="MaintenanceTypeDlgRemoveText">This will uninstall BHoM completely from your machine, removing all plugins and BHoM toolkits.</String>
   <String Id="VerifyReadyDlgRepairTitle">{\WixUI_Font_Title}Ready to reinstall [ProductName]</String>
   <String Id="VerifyReadyDlgRepairText">Click Reinstall to start reinstallation of [ProductName]. Click Back to review or change any of your installation settings. Click Cancel to exit the wizard.</String>

--- a/InstallerCore/loc/en-us.wxl
+++ b/InstallerCore/loc/en-us.wxl
@@ -9,12 +9,12 @@ NOTE: Running this installer will replace all older versions of the BHoM .dlls w
 
 Copyright (c) [CopyrightHolder]
 &lt;<![CDATA[<a href="]]>[CopyrightUrl]<![CDATA[">]]>[CopyrightUrl]<![CDATA[</a>]]>&gt;</String>
-  <String Id="MaintenanceTypeDlgTitle">Reinstall or remove BHoM installation</String>
+  <String Id="MaintenanceTypeDlgTitle">{\WixUI_Font_Title}Reinstall or remove BHoM installation</String>
   <String Id="MaintenanceTypeDlgRepairButton">Reinstall</String>
   <String Id="MaintenanceTypeDlgRepairText">Select this option to simply reinstall this version of the BHoM on your machine.</String>
   <String Id="MaintenanceTypeDlgRemoveButton">Remove</String>
   <String Id="MaintenanceTypeDlgRemoveText">This will uninstall BHoM completely from your machine, removing all plugins and BHoM toolkits.</String>
-  <String Id="VerifyReadyDlgRepairTitle">Ready to reinstall [ProductName]</String>
+  <String Id="VerifyReadyDlgRepairTitle">{\WixUI_Font_Title}Ready to reinstall [ProductName]</String>
   <String Id="VerifyReadyDlgRepairText">Click Reinstall to start reinstallation of [ProductName]. Click Back to review or change any of your installation settings. Click Cancel to exit the wizard.</String>
   <String Id="VerifyReadyDlgRepair">Reinstall</String>
 </WixLocalization>

--- a/InstallerCore/loc/en-us.wxl
+++ b/InstallerCore/loc/en-us.wxl
@@ -9,8 +9,12 @@ NOTE: Running this installer will replace all older versions of the BHoM .dlls w
 
 Copyright (c) [CopyrightHolder]
 &lt;<![CDATA[<a href="]]>[CopyrightUrl]<![CDATA[">]]>[CopyrightUrl]<![CDATA[</a>]]>&gt;</String>
+  <String Id="MaintenanceTypeDlgTitle">Reinstall or remove BHoM installation</String>
   <String Id="MaintenanceTypeDlgRepairButton">Reinstall</String>
   <String Id="MaintenanceTypeDlgRepairText">Select this option to simply reinstall this version of the BHoM on your machine.</String>
   <String Id="MaintenanceTypeDlgRemoveButton">Remove</String>
   <String Id="MaintenanceTypeDlgRemoveText">This will uninstall BHoM completely from your machine, removing all plugins and BHoM toolkits.</String>
+  <String Id="VerifyReadyDlgRepairTitle">Ready to reinstall [ProductName]</String>
+  <String Id="VerifyReadyDlgRepairText">Click Reinstall to start reinstallation of [ProductName]. Click Back to review or change any of your installation settings. Click Cancel to exit the wizard.</String>
+  <String Id="VerifyReadyDlgRepair">Reinstall</String>
 </WixLocalization>

--- a/InstallerCore/loc/en-us.wxl
+++ b/InstallerCore/loc/en-us.wxl
@@ -9,5 +9,8 @@ NOTE: Running this installer will replace all older versions of the BHoM .dlls w
 
 Copyright (c) [CopyrightHolder]
 &lt;<![CDATA[<a href="]]>[CopyrightUrl]<![CDATA[">]]>[CopyrightUrl]<![CDATA[</a>]]>&gt;</String>
-  <String Id="MaintenanceTypeDlgRepairButton">Replace</String>
+  <String Id="MaintenanceTypeDlgRepairButton">Reinstall</String>
+  <String Id="MaintenanceTypeDlgRepairText">Select this option to simply reinstall this version of the BHoM on your machine.</String>
+  <String Id="MaintenanceTypeDlgRemoveButton">Remove</String>
+  <String Id="MaintenanceTypeDlgRemoveText">This will uninstall BHoM completely from your machine, removing all plugins and BHoM toolkits.</String>
 </WixLocalization>

--- a/InstallerCore/loc/en-us.wxl
+++ b/InstallerCore/loc/en-us.wxl
@@ -12,7 +12,7 @@ Copyright (c) [CopyrightHolder]
   <String Id="MaintenanceTypeDlgTitle">{\WixUI_Font_Title}Reinstall or remove BHoM installation</String>
   <String Id="MaintenanceTypeDlgRepairButton">Reinstall</String>
   <String Id="MaintenanceTypeDlgRepairButtonTooltip">Reinstall BHoM</String>
-  <String Id="MaintenanceTypeDlgRepairText">Select this option to simply reinstall this version of the BHoM on your machine.</String>
+  <String Id="MaintenanceTypeDlgRepairText">Select this option to simply reinstall this particular version of the BHoM on your machine. Do note, this will restore the state of all toolkits and plugins to those included with this version of the BHoM.</String>
   <String Id="MaintenanceTypeDlgRemoveButton">Remove</String>
   <String Id="MaintenanceTypeDlgRemoveButtonTooltip">Remove BHoM</String>
   <String Id="MaintenanceTypeDlgRemoveText">This will uninstall BHoM completely from your machine, removing all plugins and BHoM toolkits.</String>


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #66 

<!-- Add short description of what has been fixed -->
Menu on reinstall has been simplified and terminology revised - giving now the following options
![image](https://user-images.githubusercontent.com/15924573/84492185-b2ede700-ac9d-11ea-90c5-f8efcd01e13e.png)


The previous customise menu has now been removed entirely.

### Test files
<!-- Link to test files to validate the proposed changes -->
Test asset available here: https://burohappold.sharepoint.com/sites/BHoM/Installers/Forms/AllItems.aspx?RootFolder=%2Fsites%2FBHoM%2FInstallers%2FCustom%2FMenu%20Simplification&FolderCTID=0x012000181C071E8B6D1E438B59C87DA36B9302

On testing - naturally you will only get the above **"Reinstall BHoM installation"** menu on **second** time running installer 😄 

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Ability to customise install through removal of individual plugins has been disabled. 
- Dialogue on reinstall has been simplified to just two options: 1) Reinstall and 2) Remove.
