### PR TITLE
Remove call to UI_PostBuild

### DIFF
--- a/InstallerCore/InstallerCore.wixproj
+++ b/InstallerCore/InstallerCore.wixproj
@@ -71,7 +71,6 @@
     <Error Text="The WiX Toolset v3.11 (or newer) build tools must be installed to build this project. To download the WiX Toolset, see http://wixtoolset.org/releases/" />
   </Target>
   <Target Name="BeforeBuild">
-    <Exec WorkingDirectory="$(ProjectDir)" Command="call ..\..\BHoM_UI\Build\UI_PostBuild.exe ..\..\ C:\ProgramData\BHoM\Assemblies --onlyUpgrades" />
     <Exec WorkingDirectory="$(ProjectDir)" Command="xcopy /Y /I /E $(ALLUSERSPROFILE)\BHoM\Assemblies\* Assemblies" />
     <Exec WorkingDirectory="$(ProjectDir)" Command="xcopy /Y /I /E $(ALLUSERSPROFILE)\BHoM\Upgrades\* Upgrades" />
     <Exec WorkingDirectory="$(ProjectDir)" Command="del Assemblies\*.dna Assemblies\*.xll Assemblies\*.gha" />

--- a/include.txt
+++ b/include.txt
@@ -19,5 +19,4 @@ BHoM/RFEM_Toolkit
 BHoM/Robot_Toolkit
 BHoM/SAP2000_Toolkit
 BHoM/TAS_Toolkit
-BHoM/Versioning_Toolkit
 BHoM/XML_Toolkit

--- a/userInterfaces.txt
+++ b/userInterfaces.txt
@@ -1,3 +1,4 @@
 BHoM/Grasshopper_Toolkit
 BHoM/Dynamo_Toolkit
 BHoM/Excel_Toolkit
+BHoM/Versioning_Toolkit


### PR DESCRIPTION
   
### Issues addressed by this PR

Align to the change requested in https://github.com/BHoM/BHoM_UI/issues/283

I seems to me that we can just delete the call to UI_PostBuild now as compiling the Versioning Toolkit already copies all the upgraders to ProgramData. Let me know if I missed something.


