### PR TITLE
Make sure that the sources Python files are copied

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -266,4 +266,4 @@ Dynamo13/
 Dynamo20/
 Build/
 InstallerCore/Upgrades
-python-3.7.3-embed-amd64/
+Extensions/

--- a/.gitignore
+++ b/.gitignore
@@ -266,3 +266,4 @@ Dynamo13/
 Dynamo20/
 Build/
 InstallerCore/Upgrades
+python-3.7.3-embed-amd64/

--- a/InstallerCore/Directories.wxs
+++ b/InstallerCore/Directories.wxs
@@ -7,6 +7,7 @@
           <Directory Id="ASSEMBLIESDIR" Name="Assemblies" />
           <Directory Id="FILESDIR" Name="Datasets" />
           <Directory Id="UPGRADESDIR" Name="Upgrades" />
+          <Directory Id="PYTHONDIR" Name="python-3.7.3-embed-amd64" />
         </Directory>
       </Directory>
 

--- a/InstallerCore/Directories.wxs
+++ b/InstallerCore/Directories.wxs
@@ -7,8 +7,10 @@
           <Directory Id="ASSEMBLIESDIR" Name="Assemblies" />
           <Directory Id="FILESDIR" Name="Datasets" />
           <Directory Id="UPGRADESDIR" Name="Upgrades" />
-          <Directory Id="PYTHONDIR" Name="python-3.7.3-embed-amd64" />
-        </Directory>
+          <Directory Id="EXTENSIONSDIR" Name="Extensions">
+            <Directory Id="PYTHONDIR" Name="Python" />
+            </Directory>
+          </Directory>
       </Directory>
 
 			<Directory Id="AppDataFolder">

--- a/InstallerCore/Features.wxs
+++ b/InstallerCore/Features.wxs
@@ -20,6 +20,7 @@
         <ComponentGroupRef Id="ASSEMBLIES" />
         <ComponentGroupRef Id="UPGRADES" />
         <ComponentGroupRef Id="DATA" />
+        <ComponentGroupRef Id="PYTHON" />
         <ComponentGroupRef Id="Core" />
       </Feature>
 

--- a/InstallerCore/InstallerCore.wixproj
+++ b/InstallerCore/InstallerCore.wixproj
@@ -13,7 +13,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
     <OutputPath>bin\$(Configuration)\</OutputPath>
     <IntermediateOutputPath>obj\$(Configuration)\</IntermediateOutputPath>
-    <DefineConstants>UpgradesDir=..\..\BHoM_Installer\InstallerCore\Upgrades;DataDir=..\..\BHoM_Installer\InstallerCore\DataSets;FilesDir=..\..\BHoM_Installer\InstallerCore\Assemblies;Dynamo13Dir=..\..\BHoM_Installer\InstallerCore\Dynamo13;Dynamo20Dir=..\..\BHoM_Installer\InstallerCore\Dynamo20;</DefineConstants>
+    <DefineConstants>UpgradesDir=..\..\BHoM_Installer\InstallerCore\Upgrades;DataDir=..\..\BHoM_Installer\InstallerCore\DataSets;FilesDir=..\..\BHoM_Installer\InstallerCore\Assemblies;Dynamo13Dir=..\..\BHoM_Installer\InstallerCore\Dynamo13;Dynamo20Dir=..\..\BHoM_Installer\InstallerCore\Dynamo20;PythonDir=..\..\BHoM_Installer\InstallerCore\python-3.7.3-embed-amd64</DefineConstants>
     <VerboseOutput>False</VerboseOutput>
     <LibBindFiles>False</LibBindFiles>
     <SuppressAllWarnings>False</SuppressAllWarnings>
@@ -24,7 +24,7 @@
     <IntermediateOutputPath>obj\$(Configuration)\</IntermediateOutputPath>
     <WixVariables>
     </WixVariables>
-    <DefineConstants>UpgradesDir=..\..\BHoM_Installer\InstallerCore\Upgrades;DataDir=..\..\BHoM_Installer\InstallerCore\DataSets;FilesDir=..\..\BHoM_Installer\InstallerCore\Assemblies;Dynamo13Dir=..\..\BHoM_Installer\InstallerCore\Dynamo13;Dynamo20Dir=..\..\BHoM_Installer\InstallerCore\Dynamo20;</DefineConstants>
+    <DefineConstants>UpgradesDir=..\..\BHoM_Installer\InstallerCore\Upgrades;DataDir=..\..\BHoM_Installer\InstallerCore\DataSets;FilesDir=..\..\BHoM_Installer\InstallerCore\Assemblies;Dynamo13Dir=..\..\BHoM_Installer\InstallerCore\Dynamo13;Dynamo20Dir=..\..\BHoM_Installer\InstallerCore\Dynamo20;PythonDir=..\..\BHoM_Installer\InstallerCore\python-3.7.3-embed-amd64</DefineConstants>
     <SuppressAllWarnings>False</SuppressAllWarnings>
     <Pedantic>False</Pedantic>
   </PropertyGroup>
@@ -75,6 +75,7 @@
     <Exec WorkingDirectory="$(ProjectDir)" Command="xcopy /Y /I /E $(ALLUSERSPROFILE)\BHoM\Upgrades\* Upgrades" />
     <Exec WorkingDirectory="$(ProjectDir)" Command="del Assemblies\*.dna Assemblies\*.xll Assemblies\*.gha" />
     <Exec WorkingDirectory="$(ProjectDir)" Command="xcopy /Y /I /E $(ALLUSERSPROFILE)\BHoM\Datasets DataSets" />
+    <Exec WorkingDirectory="$(ProjectDir)" Command="xcopy /Y /I /E $(ALLUSERSPROFILE)\BHoM\python-3.7.3-embed-amd64\src python-3.7.3-embed-amd64\src" />
     <Exec WorkingDirectory="$(ProjectDir)" Command="xcopy /Y /I /E ..\..\Dynamo_Toolkit\Dynamo13\Build\*.dll Dynamo13" />
     <Exec WorkingDirectory="$(ProjectDir)" Command="xcopy /Y /I /E ..\..\Dynamo_Toolkit\Dynamo20\Build\*.dll Dynamo20" />
     <HeatDirectory ToolPath="$(WixToolPath)" OutputFile="$(IntermediateOutputPath)_assemblies.wxs" DirectoryRefId="ASSEMBLIESDIR" Directory="$(ProjectDir)Assemblies" ComponentGroupName="ASSEMBLIES" PreprocessorVariable="var.FilesDir" AutogenerateGuids="false" SuppressRegistry="true" SuppressRootDirectory="true" GenerateGuidsNow="true" Transforms="$(ProjectDir)assemblies.xslt" />
@@ -82,12 +83,14 @@
     <HeatDirectory ToolPath="$(WixToolPath)" OutputFile="$(IntermediateOutputPath)_upgrades.wxs" DirectoryRefId="UPGRADESDIR" Directory="$(ProjectDir)Upgrades" ComponentGroupName="UPGRADES" PreprocessorVariable="var.UpgradesDir" AutogenerateGuids="false" SuppressRegistry="true" SuppressRootDirectory="true" GenerateGuidsNow="true" />
     <HeatDirectory ToolPath="$(WixToolPath)" OutputFile="$(IntermediateOutputPath)_dyn13assemblies.wxs" DirectoryRefId="DYNC13BHOMDIR" Directory="$(ProjectDir)Dynamo13" ComponentGroupName="DYNAMO13" PreprocessorVariable="var.Dynamo13Dir" AutogenerateGuids="false" SuppressRegistry="true" SuppressRootDirectory="true" GenerateGuidsNow="true" Transforms="$(ProjectDir)dynamo.xslt" />
     <HeatDirectory ToolPath="$(WixToolPath)" OutputFile="$(IntermediateOutputPath)_dyn20assemblies.wxs" DirectoryRefId="DYNC20BHOMDIR" Directory="$(ProjectDir)Dynamo20" ComponentGroupName="DYNAMO20" PreprocessorVariable="var.Dynamo20Dir" AutogenerateGuids="false" SuppressRegistry="true" SuppressRootDirectory="true" GenerateGuidsNow="true" Transforms="$(ProjectDir)dynamo.xslt" />
+    <HeatDirectory ToolPath="$(WixToolPath)" OutputFile="$(IntermediateOutputPath)_python.wxs" DirectoryRefId="PYTHONDIR" Directory="$(ProjectDir)python-3.7.3-embed-amd64" ComponentGroupName="PYTHON" PreprocessorVariable="var.PythonDir" AutogenerateGuids="false" SuppressRegistry="true" SuppressRootDirectory="true" GenerateGuidsNow="true" />
     <ItemGroup>
       <Compile Include="$(IntermediateOutputPath)_assemblies.wxs" />
       <Compile Include="$(IntermediateOutputPath)_datasets.wxs" />
       <Compile Include="$(IntermediateOutputPath)_upgrades.wxs" />
       <Compile Include="$(IntermediateOutputPath)_dyn13assemblies.wxs" />
       <Compile Include="$(IntermediateOutputPath)_dyn20assemblies.wxs" />
+      <Compile Include="$(IntermediateOutputPath)_python.wxs" />
     </ItemGroup>
   </Target>
 </Project>

--- a/InstallerCore/InstallerCore.wixproj
+++ b/InstallerCore/InstallerCore.wixproj
@@ -13,7 +13,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
     <OutputPath>bin\$(Configuration)\</OutputPath>
     <IntermediateOutputPath>obj\$(Configuration)\</IntermediateOutputPath>
-    <DefineConstants>UpgradesDir=..\..\BHoM_Installer\InstallerCore\Upgrades;DataDir=..\..\BHoM_Installer\InstallerCore\DataSets;FilesDir=..\..\BHoM_Installer\InstallerCore\Assemblies;Dynamo13Dir=..\..\BHoM_Installer\InstallerCore\Dynamo13;Dynamo20Dir=..\..\BHoM_Installer\InstallerCore\Dynamo20;PythonDir=..\..\BHoM_Installer\InstallerCore\python-3.7.3-embed-amd64</DefineConstants>
+    <DefineConstants>UpgradesDir=..\..\BHoM_Installer\InstallerCore\Upgrades;DataDir=..\..\BHoM_Installer\InstallerCore\DataSets;FilesDir=..\..\BHoM_Installer\InstallerCore\Assemblies;Dynamo13Dir=..\..\BHoM_Installer\InstallerCore\Dynamo13;Dynamo20Dir=..\..\BHoM_Installer\InstallerCore\Dynamo20;PythonDir=..\..\BHoM_Installer\InstallerCore\Extensions\Python</DefineConstants>
     <VerboseOutput>False</VerboseOutput>
     <LibBindFiles>False</LibBindFiles>
     <SuppressAllWarnings>False</SuppressAllWarnings>
@@ -24,7 +24,7 @@
     <IntermediateOutputPath>obj\$(Configuration)\</IntermediateOutputPath>
     <WixVariables>
     </WixVariables>
-    <DefineConstants>UpgradesDir=..\..\BHoM_Installer\InstallerCore\Upgrades;DataDir=..\..\BHoM_Installer\InstallerCore\DataSets;FilesDir=..\..\BHoM_Installer\InstallerCore\Assemblies;Dynamo13Dir=..\..\BHoM_Installer\InstallerCore\Dynamo13;Dynamo20Dir=..\..\BHoM_Installer\InstallerCore\Dynamo20;PythonDir=..\..\BHoM_Installer\InstallerCore\python-3.7.3-embed-amd64</DefineConstants>
+    <DefineConstants>UpgradesDir=..\..\BHoM_Installer\InstallerCore\Upgrades;DataDir=..\..\BHoM_Installer\InstallerCore\DataSets;FilesDir=..\..\BHoM_Installer\InstallerCore\Assemblies;Dynamo13Dir=..\..\BHoM_Installer\InstallerCore\Dynamo13;Dynamo20Dir=..\..\BHoM_Installer\InstallerCore\Dynamo20;PythonDir=..\..\BHoM_Installer\InstallerCore\Extensions\Python</DefineConstants>
     <SuppressAllWarnings>False</SuppressAllWarnings>
     <Pedantic>False</Pedantic>
   </PropertyGroup>
@@ -75,7 +75,7 @@
     <Exec WorkingDirectory="$(ProjectDir)" Command="xcopy /Y /I /E $(ALLUSERSPROFILE)\BHoM\Upgrades\* Upgrades" />
     <Exec WorkingDirectory="$(ProjectDir)" Command="del Assemblies\*.dna Assemblies\*.xll Assemblies\*.gha" />
     <Exec WorkingDirectory="$(ProjectDir)" Command="xcopy /Y /I /E $(ALLUSERSPROFILE)\BHoM\Datasets DataSets" />
-    <Exec WorkingDirectory="$(ProjectDir)" Command="xcopy /Y /I /E $(ALLUSERSPROFILE)\BHoM\python-3.7.3-embed-amd64\src python-3.7.3-embed-amd64\src" />
+    <Exec WorkingDirectory="$(ProjectDir)" Command="xcopy /Y /I /E $(ALLUSERSPROFILE)\BHoM\Extensions\Python\src Extensions\Python\src" />
     <Exec WorkingDirectory="$(ProjectDir)" Command="xcopy /Y /I /E ..\..\Dynamo_Toolkit\Dynamo13\Build\*.dll Dynamo13" />
     <Exec WorkingDirectory="$(ProjectDir)" Command="xcopy /Y /I /E ..\..\Dynamo_Toolkit\Dynamo20\Build\*.dll Dynamo20" />
     <HeatDirectory ToolPath="$(WixToolPath)" OutputFile="$(IntermediateOutputPath)_assemblies.wxs" DirectoryRefId="ASSEMBLIESDIR" Directory="$(ProjectDir)Assemblies" ComponentGroupName="ASSEMBLIES" PreprocessorVariable="var.FilesDir" AutogenerateGuids="false" SuppressRegistry="true" SuppressRootDirectory="true" GenerateGuidsNow="true" Transforms="$(ProjectDir)assemblies.xslt" />
@@ -83,7 +83,7 @@
     <HeatDirectory ToolPath="$(WixToolPath)" OutputFile="$(IntermediateOutputPath)_upgrades.wxs" DirectoryRefId="UPGRADESDIR" Directory="$(ProjectDir)Upgrades" ComponentGroupName="UPGRADES" PreprocessorVariable="var.UpgradesDir" AutogenerateGuids="false" SuppressRegistry="true" SuppressRootDirectory="true" GenerateGuidsNow="true" />
     <HeatDirectory ToolPath="$(WixToolPath)" OutputFile="$(IntermediateOutputPath)_dyn13assemblies.wxs" DirectoryRefId="DYNC13BHOMDIR" Directory="$(ProjectDir)Dynamo13" ComponentGroupName="DYNAMO13" PreprocessorVariable="var.Dynamo13Dir" AutogenerateGuids="false" SuppressRegistry="true" SuppressRootDirectory="true" GenerateGuidsNow="true" Transforms="$(ProjectDir)dynamo.xslt" />
     <HeatDirectory ToolPath="$(WixToolPath)" OutputFile="$(IntermediateOutputPath)_dyn20assemblies.wxs" DirectoryRefId="DYNC20BHOMDIR" Directory="$(ProjectDir)Dynamo20" ComponentGroupName="DYNAMO20" PreprocessorVariable="var.Dynamo20Dir" AutogenerateGuids="false" SuppressRegistry="true" SuppressRootDirectory="true" GenerateGuidsNow="true" Transforms="$(ProjectDir)dynamo.xslt" />
-    <HeatDirectory ToolPath="$(WixToolPath)" OutputFile="$(IntermediateOutputPath)_python.wxs" DirectoryRefId="PYTHONDIR" Directory="$(ProjectDir)python-3.7.3-embed-amd64" ComponentGroupName="PYTHON" PreprocessorVariable="var.PythonDir" AutogenerateGuids="false" SuppressRegistry="true" SuppressRootDirectory="true" GenerateGuidsNow="true" />
+    <HeatDirectory ToolPath="$(WixToolPath)" OutputFile="$(IntermediateOutputPath)_python.wxs" DirectoryRefId="PYTHONDIR" Directory="$(ProjectDir)Extensions\Python" ComponentGroupName="PYTHON" PreprocessorVariable="var.PythonDir" AutogenerateGuids="false" SuppressRegistry="true" SuppressRootDirectory="true" GenerateGuidsNow="true" />
     <ItemGroup>
       <Compile Include="$(IntermediateOutputPath)_assemblies.wxs" />
       <Compile Include="$(IntermediateOutputPath)_datasets.wxs" />


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #81
Closes https://github.com/BHoM/MachineLearning_Toolkit/issues/42
Closes https://github.com/BHoM/Python_Toolkit/issues/36

<!-- Add short description of what has been fixed -->
The Python_Toolkit and the MachineLearning_Toolkit, at compile time, copy the `*.py` files over to `C:\ProgramData\BHoM\python-3.7.3-embed-amd64\src` but the installer does not handle it.

This pr takes care of that.

### Test files
<!-- Link to test files to validate the proposed changes -->
DOD: after installing the BHoM you should see a folder `C:\ProgramData\BHoM\python-3.7.3-embed-amd64\src` with subfolders `Python_Toolkit` and `MachineLearning_Toolkit`. 

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->