### PR TITLE
Stop copying all DLLs to Dynamo/2.3/packages/BHoM/bin

### DIFF
--- a/InstallerCore/Features.wxs
+++ b/InstallerCore/Features.wxs
@@ -41,6 +41,7 @@
 
       <Feature Id="DynamoPlugin" Title="Dynamo Plugin" Level="1">
         <ComponentGroupRef Id="Dynamo" />
+        <ComponentGroupRef Id="DYNAMO20" />
       </Feature>
 
       <Feature Id="Settings" Title="Settings" Level="1">

--- a/InstallerCore/Features.wxs
+++ b/InstallerCore/Features.wxs
@@ -41,7 +41,6 @@
 
       <Feature Id="DynamoPlugin" Title="Dynamo Plugin" Level="1">
         <ComponentGroupRef Id="Dynamo" />
-        <ComponentGroupRef Id="DYNAMO20" />
       </Feature>
 
       <Feature Id="Settings" Title="Settings" Level="1">

--- a/InstallerCore/assemblies.xslt
+++ b/InstallerCore/assemblies.xslt
@@ -44,17 +44,11 @@
           <xsl:text>CpyDYNR23__</xsl:text>
           <xsl:value-of select="generate-id()"/>
         </xsl:attribute>
-        <xsl:attribute name="DestinationDirectory">
-          <xsl:text>DYNR23BHOMDIR</xsl:text>
-        </xsl:attribute>
       </xsl:element>
       <xsl:element name="wix:CopyFile">
         <xsl:attribute name="Id">
           <xsl:text>CpyDYNC23__</xsl:text>
           <xsl:value-of select="generate-id()"/>
-        </xsl:attribute>
-        <xsl:attribute name="DestinationDirectory">
-          <xsl:text>DYNC23BHOMDIR</xsl:text>
         </xsl:attribute>
       </xsl:element>
     </xsl:copy>


### PR DESCRIPTION
Fixes #104 


This will still copy DLLs to Dynamo to 2.0/packages/BHoM/bin
This will still install the pkg.json to 2.3/packages/BHoM
This will no longer copy all BHoM DLLs to 2.3/packages/BHoM/bin - see comments below.

~~The bin folder for 2.3/packages/BHoM is the bit I've taken out because I think that was the issue (but I'm very tired at the moment, so the odds of me misinterpreting the situation are high!~~