### PR TITLE
Fix install for Dynamo 2.3

### DIFF
--- a/InstallerCA/CustomAction.cs
+++ b/InstallerCA/CustomAction.cs
@@ -37,6 +37,59 @@ namespace InstallerCA
     {
         #region Methods
 
+        #region CaEditDynamoSettings23.xml
+        [CustomAction]
+        public static ActionResult CaEditDynamoSettings23XMLFile(Session session)
+        {
+            try
+            {
+                List<string> targetFolders = new List<string>();
+                targetFolders.Add(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "Dynamo", "Dynamo Core", "2.3"));
+                targetFolders.Add(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "Dynamo", "Dynamo Revit", "2.3"));
+
+                foreach (string targetFolder in targetFolders)
+                {
+                    string targetFile = Path.Combine(targetFolder, "DynamoSettings.xml");
+                    string templateFile = @"C:\ProgramData\BHoM\Assemblies";
+
+                    if (File.Exists(targetFile))
+                    {
+                        List<string> lines = File.ReadAllLines(targetFile).ToList();
+
+                        int index = lines.FindIndex(x => x.Contains("<CustomPackageFolders>"));
+                        if (index > 0)
+                        {
+                            int endIndex = lines.FindIndex(x => x.Contains("</CustomPackageFolders>"));
+                            if (endIndex > 0)
+                            {
+                                bool alreadyHasItem = false;
+                                for (int x = index; x < endIndex; x++)
+                                {
+                                    if (lines[x].Contains(templateFile))
+                                    {
+                                        alreadyHasItem = true;
+                                        break;
+                                    }
+                                }
+
+                                if (!alreadyHasItem)
+                                {
+                                    lines.Insert(endIndex, $"    <string>{templateFile}</string>");
+                                }
+                                File.WriteAllLines(targetFile, lines);
+                            }
+                        }
+                    }
+                }
+            }
+            catch { }
+
+            return ActionResult.Success;
+        }
+
+
+        #endregion
+
         #region CaRegisterAddIn
         [CustomAction]
         public static ActionResult CaRegisterAddIn(Session session)

--- a/InstallerCore/CustomActions.wxs
+++ b/InstallerCore/CustomActions.wxs
@@ -19,6 +19,8 @@
     <CustomAction Id="Action_UnRegisterAddInOld.SetProperty" Return="check" Property="Action_UnRegisterAddInOld" Value="FOLDER=[OLDASSEMBLIESDIR];OFFICEREGKEYS=[OFFICEREGKEYS];XLL32=[XLL32];XLL64=[XLL64]" />
     <CustomAction Id="Action_UnRegisterAddInOld" BinaryKey="InstallerCA.CA.dll" DllEntry="CaUnRegisterAddIn" Return="ignore" Execute="deferred" />
 
+    <CustomAction Id="Action_EditDynamo23SettingsXML" BinaryKey="InstallerCA.CA.dll" DllEntry="CaEditDynamoSettings23XMLFile" Return="check" Execute="commit" />
+
     <CustomAction Id="Action_CloseAppsPrompt" BinaryKey="InstallerCA.CA.dll" DllEntry="ClosePrompt" Return="check" />
 
     <SetProperty Id="GHBHoMFolder" Value="[GHBHOMDIR]" Before="CostInitialize" />

--- a/InstallerCore/Features.wxs
+++ b/InstallerCore/Features.wxs
@@ -68,5 +68,10 @@
       <ComponentGroupRef Id="ResourcesConfig" />
       <ComponentGroupRef Id="RevitResourcesConfig" />
     </Feature>
+
+    <InstallExecuteSequence>
+      <Custom Action="Action_EditDynamo23SettingsXML" Before="InstallFinalize" />
+    </InstallExecuteSequence>
+    
 	</Fragment>
 </Wix>


### PR DESCRIPTION
Fixes #118

To test:

Go to the following files:
`AppData\Roaming\Dynamo\Dynamo Core\2.3\DynamoSettings.xml`
and
`AppData\Roaming\Dynamo\Dynamo Revit\2.3\DynamoSettings.xml`

Open the files in a text editor of choice, and check if there is a line that looks like this:
`<string>C:\ProgramData\BHoM\Assemblies</string>`
within the `CustomPackageFolders` component of the XML file (approx. line 36 on my machine).

If that line exists, delete it, and save the file. Then try to run Dynamo 2.3, you should find it crashes Dynamo completely (which is the originally reported bug).

If that line does not exist then great.

Run the installer artefact produced by this PR, [available here](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?newTargetListUrl=%2Fsites%2FBHoM%2F02%5FCurrent&viewpath=%2Fsites%2FBHoM%2F02%5FCurrent%2FForms%2FAllItems%2Easpx&viewid=a5a93cba%2Dfcca%2D46cc%2Da31a%2D80b8d5cbfd7b&id=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F02%5FPull%20Request%2FBHoM%2FBHoM%5FInstaller%2F%23119%2DDynamoSettings).

Reopen the files above, confirm the line `<string>C:\ProgramData\BHoM\Assemblies</string>` now exists (or reappears if you deleted it) within the file.

Open Dynamo 2.3, create a new file. This should work without any crashing of Dynamo. BHoM in Dynamo 2.3 should then work as normal.

The issue related to #117 will not be resolved in this, so please don't get confused if that occurs, that's a separate issue not being resolved here.