### PR TITLE
Installer support for Revit_Toolkit v2022 added

### DIFF
--- a/InstallerCore/Components.wxs
+++ b/InstallerCore/Components.wxs
@@ -56,6 +56,14 @@
       </Component>
     </ComponentGroup>
 
+    <ComponentGroup Id="Revit2022" Directory="R2022DIR">
+      <Component Id="RevitAddin2022">
+        <File Source="..\..\Revit_Toolkit\Revit_Core_Adapter\Listener\Files\BHoM_2022.Addin" />
+        <util:RemoveFolderEx On="install" Property="R2022BHoMFolder" />
+        <RemoveFile On="install" Id="RemoveLegacyAddin22" Name="BHoM.Addin"/>
+      </Component>
+    </ComponentGroup>
+
     <ComponentGroup Id="Dynamo">
       <Component Id="DynPkg20" Directory="DYNAMOREVIT20BHOMDIR">
         <File Source="..\..\Dynamo_Toolkit\Dynamo20\pkg.json" Id="Dynamo20pkg">
@@ -136,6 +144,12 @@
       </Component>
     </ComponentGroup>
 
+    <ComponentGroup Id="RevitSettingsConfig2022" Directory="REVITSETTINGSDIR2022">
+      <Component Id="RevitSettingsConfig2022" Guid="81ca731c-6965-451a-9706-416db6231350">
+        <CreateFolder />
+      </Component>
+    </ComponentGroup>
+
     <ComponentGroup Id="ExtensionsConfig" Directory="EXTENSIONSDIR">
       <Component Id="ExtensionsConfig" Guid="b8cd0c91-2ebc-4bd6-ad2b-1e28fc9e6ad3">
         <CreateFolder />
@@ -168,6 +182,12 @@
 
     <ComponentGroup Id="RevitExtensionsConfig2021" Directory="REVITEXTENSIONSDIR2021">
       <Component Id="RevitExtensionsConfig2021" Guid="e963fd78-a358-43f0-959c-243c4e77de1d">
+        <CreateFolder />
+      </Component>
+    </ComponentGroup>
+
+    <ComponentGroup Id="RevitExtensionsConfig2022" Directory="REVITEXTENSIONSDIR2022">
+      <Component Id="RevitExtensionsConfig2022" Guid="b325b038-fcea-48df-819d-eb40d44f3733">
         <CreateFolder />
       </Component>
     </ComponentGroup>

--- a/InstallerCore/CustomActions.wxs
+++ b/InstallerCore/CustomActions.wxs
@@ -28,6 +28,7 @@
     <SetProperty Id="R2019BHoMFolder" Value="[R2019BHOMDIR]" Before="CostInitialize" />
     <SetProperty Id="R2020BHoMFolder" Value="[R2020BHOMDIR]" Before="CostInitialize" />
     <SetProperty Id="R2021BHoMFolder" Value="[R2021BHOMDIR]" Before="CostInitialize" />
+    <SetProperty Id="R2022BHoMFolder" Value="[R2022BHOMDIR]" Before="CostInitialize" />
 
 	</Fragment>
 </Wix>

--- a/InstallerCore/Directories.wxs
+++ b/InstallerCore/Directories.wxs
@@ -13,6 +13,7 @@
               <Directory Id="REVITSETTINGSDIR2019" Name="2019" />
               <Directory Id="REVITSETTINGSDIR2020" Name="2020" />
               <Directory Id="REVITSETTINGSDIR2021" Name="2021" />
+              <Directory Id="REVITSETTINGSDIR2022" Name="2022" />
             </Directory>
           </Directory>
           <Directory Id="LOGSDIR" Name="Logs" />
@@ -26,6 +27,7 @@
               <Directory Id="REVITEXTENSIONSDIR2019" Name="2019" />
               <Directory Id="REVITEXTENSIONSDIR2020" Name="2020" />
               <Directory Id="REVITEXTENSIONSDIR2021" Name="2021" />
+              <Directory Id="REVITEXTENSIONSDIR2022" Name="2022" />
             </Directory>
            </Directory>
 
@@ -60,6 +62,9 @@
               </Directory>
               <Directory Id="R2021DIR" Name="2021">
                 <Directory Id="R2021BHOMDIR" Name="BHoM" />
+              </Directory>
+              <Directory Id="R2022DIR" Name="2022">
+                <Directory Id="R2022BHOMDIR" Name="BHoM" />
               </Directory>
             </Directory>
           </Directory>

--- a/InstallerCore/Features.wxs
+++ b/InstallerCore/Features.wxs
@@ -40,6 +40,7 @@
         <ComponentGroupRef Id="Revit2019" />
         <ComponentGroupRef Id="Revit2020" />
         <ComponentGroupRef Id="Revit2021" />
+        <ComponentGroupRef Id="Revit2022" />
       </Feature>
 
       <Feature Id="DynamoPlugin" Title="Dynamo Plugin" Level="1">
@@ -54,6 +55,7 @@
         <ComponentGroupRef Id="RevitSettingsConfig2019" />
         <ComponentGroupRef Id="RevitSettingsConfig2020" />
         <ComponentGroupRef Id="RevitSettingsConfig2021" />
+        <ComponentGroupRef Id="RevitSettingsConfig2022" />
       </Feature>
 
       <Feature Id="Extensions" Title="Extensions" Level="1">
@@ -63,6 +65,7 @@
         <ComponentGroupRef Id="RevitExtensionsConfig2019" />
         <ComponentGroupRef Id="RevitExtensionsConfig2020" />
         <ComponentGroupRef Id="RevitExtensionsConfig2021" />
+        <ComponentGroupRef Id="RevitExtensionsConfig2022" />
       </Feature>
     </FeatureGroup>
 

--- a/altConfigs.txt
+++ b/altConfigs.txt
@@ -2,6 +2,7 @@ BHoM/Revit_Toolkit/Release2018
 BHoM/Revit_Toolkit/Release2019
 BHoM/Revit_Toolkit/Release2020
 BHoM/Revit_Toolkit/Release2021
+BHoM/Revit_Toolkit/Release2022
 BHoM/ETABS_Toolkit/Release16
 BHoM/ETABS_Toolkit/Release17
 BHoM/ETABS_Toolkit/Release18


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->
https://github.com/BHoM/Revit_Toolkit/pull/1072

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #132

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
Ideally I would like to see the installer with Revit_Toolkit v2022 landing in [this SharePoint folder](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?RootFolder=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F02%5FPull%20Request%2FBHoM%2FRevit%5FToolkit%2F%231072%2DRevit2022Support&FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4).


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->