### PR TITLE
Remove Revit 2018/2019 options from the installer

### DIFF
--- a/IncludedRepos/altConfigs.txt
+++ b/IncludedRepos/altConfigs.txt
@@ -1,5 +1,3 @@
-BHoM/Revit_Toolkit/Release2018
-BHoM/Revit_Toolkit/Release2019
 BHoM/Revit_Toolkit/Release2020
 BHoM/Revit_Toolkit/Release2021
 BHoM/Revit_Toolkit/Release2022

--- a/InstallerCore/Components.wxs
+++ b/InstallerCore/Components.wxs
@@ -24,22 +24,6 @@
       </Component>
     </ComponentGroup>
 
-    <ComponentGroup Id="Revit2018" Directory="R2018DIR">
-      <Component Id="RevitAddin2018">
-        <File Source="..\..\Revit_Toolkit\Revit_Core_Adapter\Listener\Files\BHoM_2018.Addin" />
-        <util:RemoveFolderEx On="install" Property="R2018BHoMFolder" />
-        <RemoveFile On="install" Id="RemoveLegacyAddin18" Name="BHoM.Addin"/>
-      </Component>
-    </ComponentGroup>
-
-    <ComponentGroup Id="Revit2019" Directory="R2019DIR">
-      <Component Id="RevitAddin2019">
-        <File Source="..\..\Revit_Toolkit\Revit_Core_Adapter\Listener\Files\BHoM_2019.Addin" />
-        <util:RemoveFolderEx On="install" Property="R2019BHoMFolder" />
-        <RemoveFile On="install" Id="RemoveLegacyAddin19" Name="BHoM.Addin"/>
-      </Component>
-    </ComponentGroup>
-
     <ComponentGroup Id="Revit2020" Directory="R2020DIR">
       <Component Id="RevitAddin2020">
         <File Source="..\..\Revit_Toolkit\Revit_Core_Adapter\Listener\Files\BHoM_2020.Addin" />
@@ -128,18 +112,6 @@
       </Component>
     </ComponentGroup>
 
-    <ComponentGroup Id="RevitSettingsConfig2018" Directory="REVITSETTINGSDIR2018">
-      <Component Id="RevitSettingsConfig2018" Guid="2be4f87d-f4c7-4324-b45f-cc27e72c4815">
-        <CreateFolder />
-      </Component>
-    </ComponentGroup>
-
-    <ComponentGroup Id="RevitSettingsConfig2019" Directory="REVITSETTINGSDIR2019">
-      <Component Id="RevitSettingsConfig2019" Guid="d966df84-4493-4091-bc21-8c65a0fcd581">
-        <CreateFolder />
-      </Component>
-    </ComponentGroup>
-
     <ComponentGroup Id="RevitSettingsConfig2020" Directory="REVITSETTINGSDIR2020">
       <Component Id="RevitSettingsConfig2020" Guid="3a68c387-b031-4aa1-affe-eb2c25d80322">
         <CreateFolder />
@@ -172,18 +144,6 @@
     
     <ComponentGroup Id="RevitExtensionsConfig" Directory="REVITEXTENSIONSDIR">
       <Component Id="RevitExtensionsConfig" Guid="6cf78449-1a6e-42c5-8212-9e39e85dcc59">
-        <CreateFolder />
-      </Component>
-    </ComponentGroup>
-    
-    <ComponentGroup Id="RevitExtensionsConfig2018" Directory="REVITEXTENSIONSDIR2018">
-      <Component Id="RevitExtensionsConfig2018" Guid="2b143a1d-0630-4a10-a040-f91e2347b353">
-        <CreateFolder />
-      </Component>
-    </ComponentGroup>
-    
-    <ComponentGroup Id="RevitExtensionsConfig2019" Directory="REVITEXTENSIONSDIR2019">
-      <Component Id="RevitExtensionsConfig2019" Guid="0c8902fe-bd87-4759-bce0-497a28ce5612">
         <CreateFolder />
       </Component>
     </ComponentGroup>

--- a/InstallerCore/Directories.wxs
+++ b/InstallerCore/Directories.wxs
@@ -10,8 +10,6 @@
           <Directory Id="SETTINGSDIR" Name="Settings">
             <Directory Id="PYTHONSETTINGSDIR" Name="Python" />
             <Directory Id="REVITSETTINGSDIR" Name="Revit">
-              <Directory Id="REVITSETTINGSDIR2018" Name="2018" />
-              <Directory Id="REVITSETTINGSDIR2019" Name="2019" />
               <Directory Id="REVITSETTINGSDIR2020" Name="2020" />
               <Directory Id="REVITSETTINGSDIR2021" Name="2021" />
               <Directory Id="REVITSETTINGSDIR2022" Name="2022" />
@@ -22,8 +20,6 @@
           <Directory Id="EXTENSIONSDIR" Name="Extensions">
             <Directory Id="PYTHONCODEDIR" Name="PythonCode" />
             <Directory Id="REVITEXTENSIONSDIR" Name="Revit">
-              <Directory Id="REVITEXTENSIONSDIR2018" Name="2018" />              
-              <Directory Id="REVITEXTENSIONSDIR2019" Name="2019" />
               <Directory Id="REVITEXTENSIONSDIR2020" Name="2020" />
               <Directory Id="REVITEXTENSIONSDIR2021" Name="2021" />
               <Directory Id="REVITEXTENSIONSDIR2022" Name="2022" />

--- a/InstallerCore/Features.wxs
+++ b/InstallerCore/Features.wxs
@@ -32,9 +32,7 @@
         <ComponentGroupRef Id="Grasshopper" />
       </Feature>
 
-      <Feature Id="Revit2018Plugin" Title="Revit Plugin" Level="1">
-        <ComponentGroupRef Id="Revit2018" />
-        <ComponentGroupRef Id="Revit2019" />
+      <Feature Id="RevitPlugin" Title="Revit Plugin" Level="1">
         <ComponentGroupRef Id="Revit2020" />
         <ComponentGroupRef Id="Revit2021" />
         <ComponentGroupRef Id="Revit2022" />
@@ -49,8 +47,6 @@
       <Feature Id="Settings" Title="Settings" Level="1">
         <ComponentGroupRef Id="SettingsConfig" />
         <ComponentGroupRef Id="RevitSettingsConfig" />
-        <ComponentGroupRef Id="RevitSettingsConfig2018" />
-        <ComponentGroupRef Id="RevitSettingsConfig2019" />
         <ComponentGroupRef Id="RevitSettingsConfig2020" />
         <ComponentGroupRef Id="RevitSettingsConfig2021" />
         <ComponentGroupRef Id="RevitSettingsConfig2022" />
@@ -60,8 +56,6 @@
       <Feature Id="Extensions" Title="Extensions" Level="1">
         <ComponentGroupRef Id="ExtensionsConfig" />
         <ComponentGroupRef Id="RevitExtensionsConfig" />
-        <ComponentGroupRef Id="RevitExtensionsConfig2018" />
-        <ComponentGroupRef Id="RevitExtensionsConfig2019" />
         <ComponentGroupRef Id="RevitExtensionsConfig2020" />
         <ComponentGroupRef Id="RevitExtensionsConfig2021" />
         <ComponentGroupRef Id="RevitExtensionsConfig2022" />


### PR DESCRIPTION
Based on the work to support Revit Toolkit stopping support for Revit 18/19.