### PR TITLE
Add ETABS Release21

### DIFF
--- a/IncludedRepos/altConfigs.txt
+++ b/IncludedRepos/altConfigs.txt
@@ -6,6 +6,7 @@ BHoM/Revit_Toolkit/Release2024
 BHoM/ETABS_Toolkit/Release
 BHoM/ETABS_Toolkit/Release16
 BHoM/ETABS_Toolkit/Release17
+BHoM/ETABS_Toolkit/Release21
 BHoM/Lusas_Toolkit/Release17
 BHoM/Lusas_Toolkit/Release18
 BHoM/Lusas_Toolkit/Release19


### PR DESCRIPTION
### Issues addressed by this PR

Related to https://github.com/BHoM/ETABS_Toolkit/issues/482


ETABS 21 has been found to have some particular issues in its API that are not present in previous versions of the software. Having a specific configuration for it allows to isolate and sort these issues separately from the other versions.