### PR TITLE
Add release 220 and remove dormant adapter versions

### DIFF
--- a/IncludedRepos/altConfigs.txt
+++ b/IncludedRepos/altConfigs.txt
@@ -6,13 +6,9 @@ BHoM/Revit_Toolkit/Release2025
 BHoM/ETABS_Toolkit/Release
 BHoM/ETABS_Toolkit/Release16
 BHoM/ETABS_Toolkit/Release17
-BHoM/Lusas_Toolkit/Release17
-BHoM/Lusas_Toolkit/Release18
-BHoM/Lusas_Toolkit/Release19
-BHoM/Lusas_Toolkit/Release191
-BHoM/Lusas_Toolkit/Release200
 BHoM/Lusas_Toolkit/Release210
 BHoM/Lusas_Toolkit/Release211
+BHoM/Lusas_Toolkit/Release220
 BHoM/GSA_Toolkit/Release87
 BHoM/GSA_Toolkit/Release101
 BHoM/GSA_Toolkit/Release102


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->
https://github.com/BHoM/Lusas_Toolkit/pull/431
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #241 

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Added Lusas220 to alt config and removed versions of Lusas below 210 - these are still available in the source code.

### Additional comments
<!-- As required -->