### PR TITLE
Align installer with new strategy of installing GH in a separate folder

### DIFF
--- a/InstallerCore/Components.wxs
+++ b/InstallerCore/Components.wxs
@@ -17,7 +17,7 @@
       </Component>
     </ComponentGroup>
 
-    <ComponentGroup Id="Grasshopper" Directory="ASSEMBLIESDIR">
+    <ComponentGroup Id="Grasshopper" Directory="GRASSHOPPERPLUGINDIR">
       <Component Id="GHA" Guid="{A1EE1994-996D-4AF2-B61E-DA5C910534CC}">
         <File KeyPath="yes" Source="..\..\Grasshopper_UI\Build\BH.UI.Grasshopper.dll" Name="BH.UI.Grasshopper.gha" />
         <util:RemoveFolderEx On="install" Property="GHBHoMFolder" />
@@ -70,6 +70,7 @@
           <RegistryValue Name="Installer" Type="integer" Value="1"></RegistryValue>
         </RegistryKey>
         <util:RemoveFolderEx On="both" Property="ASSEMBLIESDIR" />
+        <util:RemoveFolderEx On="both" Property="GRASSHOPPERPLUGINDIR" />
         <util:RemoveFolderEx On="both" Property="FILESDIR" />
         <util:RemoveFolderEx On="both" Property="UPGRADESDIR" />
         <util:RemoveFolderEx On="both" Property="OLDINSTALLFOLDER" />

--- a/InstallerCore/CustomActions.wxs
+++ b/InstallerCore/CustomActions.wxs
@@ -9,7 +9,7 @@
 
     <Binary Id="InstallerCA.CA.dll" SourceFile="$(var.InstallerCA.TargetDir)$(var.InstallerCA.TargetName).CA.dll" />
 
-    <CustomAction Id="GenGHLink" Directory="GHLIBSDIR" ExeCommand="cmd.exe /c &quot;echo [ASSEMBLIESDIR]BH.UI.Grasshopper.gha &gt; BH.UI.Grasshopper.ghlink&quot;" Execute="commit" Return="ignore"></CustomAction>
+    <CustomAction Id="GenGHLink" Directory="GHLIBSDIR" ExeCommand="cmd.exe /c &quot;echo [GRASSHOPPERPLUGINDIR]BH.UI.Grasshopper.gha &gt; BH.UI.Grasshopper.ghlink&quot;" Execute="commit" Return="ignore"></CustomAction>
     <CustomAction Id="DelGHLink" Directory="GHLIBSDIR" ExeCommand="cmd.exe /c &quot;del BH.UI.Grasshopper.ghlink&quot;" Execute="commit" Return="ignore"></CustomAction>
 
     <CustomAction Id="Action_RegisterAddIn.SetProperty" Return="check" Property="Action_RegisterAddIn" Value="FOLDER=[ASSEMBLIESDIR];OFFICEREGKEYS=[OFFICEREGKEYS];XLL32=[XLL32];XLL64=[XLL64]" />

--- a/InstallerCore/Directories.wxs
+++ b/InstallerCore/Directories.wxs
@@ -5,6 +5,7 @@
 			<Directory Id="CommonAppDataFolder">
         <Directory Id="INSTALLFOLDER" Name="BHoM">
           <Directory Id="ASSEMBLIESDIR" Name="Assemblies" />
+          <Directory Id="GRASSHOPPERPLUGINDIR" Name="GrasshopperPlugin" />
           <Directory Id="FILESDIR" Name="Datasets" />
           <Directory Id="UPGRADESDIR" Name="Upgrades" />
           <Directory Id="SETTINGSDIR" Name="Settings">

--- a/InstallerCore/Features.wxs
+++ b/InstallerCore/Features.wxs
@@ -30,6 +30,7 @@
 
       <Feature Id="GrasshopperPlugin" Title="Grasshopper Plugin" Level="1">
         <ComponentGroupRef Id="Grasshopper" />
+        <ComponentGroupRef Id="GRASSHOPPERPLUGIN" />
       </Feature>
 
       <Feature Id="RevitPlugin" Title="Revit Plugin" Level="1">

--- a/InstallerCore/InstallerCore.wixproj
+++ b/InstallerCore/InstallerCore.wixproj
@@ -13,7 +13,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
     <OutputPath>bin\$(Configuration)\</OutputPath>
     <IntermediateOutputPath>obj\$(Configuration)\</IntermediateOutputPath>
-    <DefineConstants>UpgradesDir=..\..\BHoM_Installer\InstallerCore\Upgrades;DataDir=..\..\BHoM_Installer\InstallerCore\DataSets;FilesDir=..\..\BHoM_Installer\InstallerCore\Assemblies;ResourcesDir=..\..\BHoM_Installer\InstallerCore\Resources;PythonCodeDir=..\..\BHoM_Installer\InstallerCore\Extensions\PythonCode</DefineConstants>
+    <DefineConstants>UpgradesDir=..\..\BHoM_Installer\InstallerCore\Upgrades;DataDir=..\..\BHoM_Installer\InstallerCore\DataSets;FilesDir=..\..\BHoM_Installer\InstallerCore\Assemblies;ResourcesDir=..\..\BHoM_Installer\InstallerCore\Resources;PythonCodeDir=..\..\BHoM_Installer\InstallerCore\Extensions\PythonCode;GrasshopperPluginDir=..\..\BHoM_Installer\InstallerCore\GrasshopperPlugin</DefineConstants>
     <VerboseOutput>False</VerboseOutput>
     <LibBindFiles>False</LibBindFiles>
     <SuppressAllWarnings>False</SuppressAllWarnings>
@@ -25,7 +25,7 @@
     <IntermediateOutputPath>obj\$(Configuration)\</IntermediateOutputPath>
     <WixVariables>
     </WixVariables>
-    <DefineConstants>UpgradesDir=..\..\BHoM_Installer\InstallerCore\Upgrades;DataDir=..\..\BHoM_Installer\InstallerCore\DataSets;FilesDir=..\..\BHoM_Installer\InstallerCore\Assemblies;</DefineConstants>
+    <DefineConstants>UpgradesDir=..\..\BHoM_Installer\InstallerCore\Upgrades;DataDir=..\..\BHoM_Installer\InstallerCore\DataSets;FilesDir=..\..\BHoM_Installer\InstallerCore\Assemblies;GrasshopperPluginDir=..\..\BHoM_Installer\InstallerCore\GrasshopperPlugin</DefineConstants>
     <SuppressAllWarnings>False</SuppressAllWarnings>
     <Pedantic>False</Pedantic>
     <RunWixToolsOutOfProc Condition=" '$(PROCESSOR_ARCHITECTURE)'!='x86' ">true</RunWixToolsOutOfProc>
@@ -74,21 +74,25 @@
   <Target Name="BeforeBuild">
     <Exec WorkingDirectory="$(ProjectDir)" Command="xcopy /Y /I /E $(ALLUSERSPROFILE)\BHoM\Assemblies\* Assemblies" />
     <Exec WorkingDirectory="$(ProjectDir)" Command="xcopy /Y /I /E $(ALLUSERSPROFILE)\BHoM\Upgrades\* Upgrades" />
-    <Exec WorkingDirectory="$(ProjectDir)" Command="del Assemblies\*.dna Assemblies\*.xll Assemblies\*.gha" />
+    <Exec WorkingDirectory="$(ProjectDir)" Command="del Assemblies\*.dna Assemblies\*.xll" />
     <Exec WorkingDirectory="$(ProjectDir)" Command="xcopy /Y /I /E $(ALLUSERSPROFILE)\BHoM\Datasets DataSets" />
     <Exec WorkingDirectory="$(ProjectDir)" Command="xcopy /Y /I /E $(ALLUSERSPROFILE)\BHoM\Extensions\PythonCode\* Extensions\PythonCode" />
     <Exec WorkingDirectory="$(ProjectDir)" Command="xcopy /Y /I /E /C $(ALLUSERSPROFILE)\BHoM\Resources\* Resources" />
+    <Exec WorkingDirectory="$(ProjectDir)" Command="xcopy /Y /I /E $(ALLUSERSPROFILE)\BHoM\GrasshopperPlugin\* GrasshopperPlugin" />
+    <Exec WorkingDirectory="$(ProjectDir)" Command="del GrasshopperPlugin\*.gha" />
     <HeatDirectory ToolPath="$(WixToolPath)" OutputFile="$(IntermediateOutputPath)_resources.wxs" DirectoryRefId="RESOURCESDIR" Directory="$(ProjectDir)Resources" ComponentGroupName="RESOURCES" PreprocessorVariable="var.ResourcesDir" AutogenerateGuids="false" SuppressRegistry="true" SuppressRootDirectory="true" GenerateGuidsNow="true" RunAsSeparateProcess="$(RunWixToolsOutOfProc)" />
     <HeatDirectory ToolPath="$(WixToolPath)" OutputFile="$(IntermediateOutputPath)_assemblies.wxs" DirectoryRefId="ASSEMBLIESDIR" Directory="$(ProjectDir)Assemblies" ComponentGroupName="ASSEMBLIES" PreprocessorVariable="var.FilesDir" AutogenerateGuids="false" SuppressRegistry="true" SuppressRootDirectory="true" GenerateGuidsNow="true" Transforms="$(ProjectDir)assemblies.xslt" RunAsSeparateProcess="$(RunWixToolsOutOfProc)" />
     <HeatDirectory ToolPath="$(WixToolPath)" OutputFile="$(IntermediateOutputPath)_datasets.wxs" DirectoryRefId="FILESDIR" Directory="$(ProjectDir)DataSets" ComponentGroupName="DATA" PreprocessorVariable="var.DataDir" AutogenerateGuids="false" SuppressRegistry="true" SuppressRootDirectory="true" GenerateGuidsNow="true" RunAsSeparateProcess="$(RunWixToolsOutOfProc)" />
     <HeatDirectory ToolPath="$(WixToolPath)" OutputFile="$(IntermediateOutputPath)_upgrades.wxs" DirectoryRefId="UPGRADESDIR" Directory="$(ProjectDir)Upgrades" ComponentGroupName="UPGRADES" PreprocessorVariable="var.UpgradesDir" AutogenerateGuids="false" SuppressRegistry="true" SuppressRootDirectory="true" GenerateGuidsNow="true" RunAsSeparateProcess="$(RunWixToolsOutOfProc)" />
     <HeatDirectory ToolPath="$(WixToolPath)" OutputFile="$(IntermediateOutputPath)_pythoncode.wxs" DirectoryRefId="PYTHONCODEDIR" Directory="$(ProjectDir)Extensions\PythonCode" ComponentGroupName="PYTHONCODE" PreprocessorVariable="var.PythonCodeDir" AutogenerateGuids="false" SuppressRegistry="true" SuppressRootDirectory="true" GenerateGuidsNow="true" RunAsSeparateProcess="$(RunWixToolsOutOfProc)" />
+    <HeatDirectory ToolPath="$(WixToolPath)" OutputFile="$(IntermediateOutputPath)_grasshopperplugin.wxs" DirectoryRefId="GRASSHOPPERPLUGINDIR" Directory="$(ProjectDir)GrasshopperPlugin" ComponentGroupName="GRASSHOPPERPLUGIN" PreprocessorVariable="var.GrasshopperPluginDir" AutogenerateGuids="false" SuppressRegistry="true" SuppressRootDirectory="true" GenerateGuidsNow="true" RunAsSeparateProcess="$(RunWixToolsOutOfProc)" />
     <ItemGroup>
       <Compile Include="$(IntermediateOutputPath)_assemblies.wxs" />
       <Compile Include="$(IntermediateOutputPath)_datasets.wxs" />
       <Compile Include="$(IntermediateOutputPath)_upgrades.wxs" />
       <Compile Include="$(IntermediateOutputPath)_pythoncode.wxs" />
       <Compile Include="$(IntermediateOutputPath)_resources.wxs" />
+      <Compile Include="$(IntermediateOutputPath)_grasshopperplugin.wxs" />
     </ItemGroup>
   </Target>
 </Project>


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
https://github.com/BHoM/Grasshopper_UI/pull/733

   
### Issues addressed by this PR
See the Grasshopper PR for details.

This makes sure that the new `C:\ProgramData\BHoM\GrasshopperPlugin` folder is installed properly once the Grasshopper PR is merged.


### Test files
@michaelhoehn , can we try to generate a test installer from this PR ?

