### PR TITLE
feat: cumulative-since-stable changelog model + rule 6

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,6 +3,10 @@
 ###############################################################################
 * text=auto
 
+# Shell scripts must end with LF on every platform; they run on Linux runners
+# where CRLF would break the shebang ('/bin/bash^M: bad interpreter').
+*.sh text eol=lf
+
 ###############################################################################
 # Set default behavior for command prompt diff.
 #

--- a/.github/workflows/build-installer.yml
+++ b/.github/workflows/build-installer.yml
@@ -147,6 +147,8 @@ jobs:
         # publish-alpha job downloads the previous release's copy of this file
         # and diffs it against this one to render "what changed since last build"
         # release notes.
+        env:
+          RELEASE_TYPE: ${{ inputs.release_type || 'alpha' }}
         run: |
           $depsObject = [ordered]@{}
           Get-ChildItem 'D:\a\BHoM_Installer' -Directory -ErrorAction SilentlyContinue |
@@ -166,12 +168,12 @@ jobs:
           $manifest = [ordered]@{
               version       = 1
               built_at      = (Get-Date).ToUniversalTime().ToString('o')
-              release_type  = '${{ inputs.release_type || ''alpha'' }}'
+              release_type  = $env:RELEASE_TYPE
               main_branch   = 'develop'
               deps          = $depsObject
           }
 
-          $outPath = "${{ github.workspace }}/Build/dep-manifest.json"
+          $outPath = Join-Path $env:GITHUB_WORKSPACE 'Build\dep-manifest.json'
           $manifest | ConvertTo-Json -Depth 10 | Set-Content -Path $outPath -Encoding UTF8
           Write-Host "::notice::Wrote dep-manifest.json with $($depsObject.Count) deps"
 

--- a/.github/workflows/build-installer.yml
+++ b/.github/workflows/build-installer.yml
@@ -338,20 +338,23 @@ jobs:
           if-no-files-found: warn
           retention-days: 14
 
-  # Publish the validated .msi to a rolling 'nightly-alpha' Release tag.
-  # Same tag is updated on every successful nightly + dispatch build, so users
-  # have one stable URL for the latest alpha:
-  #   https://github.com/<repo>/releases/tag/nightly-alpha
+  # Publish the .msi as a preserved per-build Release. Tag scheme:
+  #   schedule         → alpha-{YYYYMMDD}                    (one per day)
+  #   workflow_dispatch → manual-alpha-{YYYYMMDD-HHMMSS}    (one per dispatch)
+  # No rolling tag: each release stays as history. No "skip if unchanged"
+  # gate: the build itself runs every cycle as a CI heartbeat.
   #
-  # Gated behind install-test passing on all matrix legs. Only publishes alphas
-  # (beta and other release types are skipped here — they'd get their own tag
-  # in a future iteration). prerelease: true keeps the 'Latest release' badge
-  # reserved for semver-tagged stable builds.
+  # Publishes even if install-test failed — the .msi is still useful for
+  # local diagnostic testing. The body surfaces the test result so users
+  # know whether to trust the build for production use.
   publish-alpha:
-    name: Publish nightly-alpha release
+    name: Publish alpha release
     needs: [build, install-test]
+    # always() overrides the implicit "all needs succeeded" gate so that
+    # install-test failure doesn't block publishing.
     if: |
-      success() &&
+      always() &&
+      needs.build.result == 'success' &&
       (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') &&
       (inputs.release_type == 'alpha' || inputs.release_type == null || inputs.release_type == '')
     runs-on: ubuntu-latest
@@ -372,22 +375,48 @@ jobs:
           name: installer-${{ inputs.release_type || 'alpha' }}-${{ github.run_id }}
           path: artefact
 
-      - name: Download previous nightly-alpha dep-manifest (if any)
+      - name: Compute release tag + name
+        id: tag
+        shell: bash
+        run: |
+          set -eu
+          if [ "$GITHUB_EVENT_NAME" = "schedule" ]; then
+              tag="alpha-$(date -u +%Y%m%d)"
+              name="BHoM Alpha — $(date -u +%Y-%m-%d)"
+          else
+              tag="manual-alpha-$(date -u +%Y%m%d-%H%M%S)"
+              name="BHoM Alpha — manual $(date -u +'%Y-%m-%d %H:%M:%S') UTC"
+          fi
+          echo "tag=$tag"   >> "$GITHUB_OUTPUT"
+          echo "name=$name" >> "$GITHUB_OUTPUT"
+          echo "::notice::Release tag = $tag"
+
+      - name: Find + download most recent prior alpha dep-manifest (for diff)
         id: prev-manifest
         env:
           GH_TOKEN: ${{ github.token }}
+          CURRENT_TAG: ${{ steps.tag.outputs.tag }}
         run: |
           set -eu
           mkdir -p prev
-          if gh release download nightly-alpha \
+          # List releases, pick the most recent alpha-*/manual-alpha-* whose tag
+          # isn't the one we're about to publish.
+          prev_tag=$(gh release list \
+              --repo "$GITHUB_REPOSITORY" \
+              --limit 50 \
+              --json tagName,createdAt \
+              --jq "[.[] | select(.tagName | test(\"^(alpha|manual-alpha)-\")) | select(.tagName != \"$CURRENT_TAG\")] | sort_by(.createdAt) | reverse | .[0].tagName // \"\"")
+          if [ -n "$prev_tag" ] && gh release download "$prev_tag" \
               --repo "$GITHUB_REPOSITORY" \
               --pattern dep-manifest.json \
               --dir prev 2>/dev/null; then
-              echo "Previous nightly-alpha manifest downloaded"
+              echo "::notice::Diffing against previous release: $prev_tag"
               echo "path=prev/dep-manifest.json" >> "$GITHUB_OUTPUT"
+              echo "prev_tag=$prev_tag"          >> "$GITHUB_OUTPUT"
           else
-              echo "::notice::No previous nightly-alpha release found — this will be an initial publish"
-              echo "path=" >> "$GITHUB_OUTPUT"
+              echo "::notice::No prior alpha release with a manifest — this will be an initial-baseline publish"
+              echo "path="     >> "$GITHUB_OUTPUT"
+              echo "prev_tag=" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Generate dep-change release-notes section
@@ -400,20 +429,37 @@ jobs:
               release-notes-section.md
 
       - name: Compose full release body
+        env:
+          INSTALL_TEST_RESULT: ${{ needs.install-test.result }}
+          PREV_TAG:            ${{ steps.prev-manifest.outputs.prev_tag }}
         run: |
-          cat >release-body.md <<'EOF'
-          **Latest BHoM alpha build.**
+          set -eu
+          run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
 
-          - Build: [#${{ github.run_id }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
-          - Commit: `${{ github.sha }}`
-          - Triggered by: `${{ github.event_name }}`
+          if [ "$INSTALL_TEST_RESULT" = "success" ]; then
+              test_status="✅ install + uninstall smoke test passed on both windows-2022 and windows-2025"
+          else
+              test_status="⚠️ install + uninstall smoke test result: \`$INSTALL_TEST_RESULT\` — see [run logs]($run_url). **Download for diagnostic / local testing only — do not promote to users.**"
+          fi
 
-          Install: download the `.msi`, double-click. Uninstall via Windows
+          if [ -n "$PREV_TAG" ]; then
+              diff_note="Diffed against [\`$PREV_TAG\`](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/releases/tag/${PREV_TAG})."
+          else
+              diff_note="(No prior alpha release found — this is an initial baseline.)"
+          fi
+
+          cat >release-body.md <<EOF
+          **BHoM alpha build.**
+
+          - Build: [#${GITHUB_RUN_ID}]($run_url)
+          - Commit: \`${GITHUB_SHA}\`
+          - Triggered by: \`${GITHUB_EVENT_NAME}\`
+          - **Test status:** $test_status
+
+          Install: download the \`.msi\`, double-click. Uninstall via Windows
           "Apps & Features".
 
-          This tag is re-issued on every successful nightly build and on
-          on-demand `workflow_dispatch` runs — bookmark this page for the
-          latest alpha.
+          $diff_note
 
           ---
 
@@ -423,11 +469,11 @@ jobs:
           echo "=== Release body preview (first 80 lines) ==="
           head -80 release-body.md
 
-      - name: Publish / update rolling release
+      - name: Publish release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: nightly-alpha
-          name: BHoM Alpha (Nightly)
+          tag_name: ${{ steps.tag.outputs.tag }}
+          name: ${{ steps.tag.outputs.name }}
           body_path: release-body.md
           files: |
             artefact/*.msi

--- a/.github/workflows/build-installer.yml
+++ b/.github/workflows/build-installer.yml
@@ -141,6 +141,40 @@ jobs:
 
           & "$env:GITHUB_WORKSPACE\scripts\Build-Installer.ps1" @splat
 
+      - name: Generate dep manifest (for release-note diffing)
+        # Walk the cloned dep repos that sit alongside the installer checkout
+        # and record each one's (org/repo, branch, current tip SHA). The
+        # publish-alpha job downloads the previous release's copy of this file
+        # and diffs it against this one to render "what changed since last build"
+        # release notes.
+        run: |
+          $depsObject = [ordered]@{}
+          Get-ChildItem 'D:\a\BHoM_Installer' -Directory -ErrorAction SilentlyContinue |
+              Where-Object { $_.Name -ne 'BHoM_Installer' -and (Test-Path (Join-Path $_.FullName '.git')) } |
+              Sort-Object Name |
+              ForEach-Object {
+                  $remoteUrl = (git -C $_.FullName config --get remote.origin.url 2>$null)
+                  if ($remoteUrl -match 'github\.com[/:]([^/]+)/([^/.]+?)(?:\.git)?$') {
+                      $orgRepo = "$($Matches[1])/$($Matches[2])"
+                      $sha = (git -C $_.FullName rev-parse HEAD 2>$null).Trim()
+                      if ($sha) {
+                          $depsObject[$orgRepo] = [ordered]@{ branch = 'develop'; sha = $sha }
+                      }
+                  }
+              }
+
+          $manifest = [ordered]@{
+              version       = 1
+              built_at      = (Get-Date).ToUniversalTime().ToString('o')
+              release_type  = '${{ inputs.release_type || ''alpha'' }}'
+              main_branch   = 'develop'
+              deps          = $depsObject
+          }
+
+          $outPath = "${{ github.workspace }}/Build/dep-manifest.json"
+          $manifest | ConvertTo-Json -Depth 10 | Set-Content -Path $outPath -Encoding UTF8
+          Write-Host "::notice::Wrote dep-manifest.json with $($depsObject.Count) deps"
+
       - name: Assert .msi size is sane
         # Catches catastrophic packaging regressions: a tiny .msi means WiX shipped
         # nearly nothing; a huge one means something is being bundled that shouldn't
@@ -160,7 +194,9 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: installer-${{ inputs.release_type || 'alpha' }}-${{ github.run_id }}
-          path: ${{ github.workspace }}/Build/*.msi
+          path: |
+            ${{ github.workspace }}/Build/*.msi
+            ${{ github.workspace }}/Build/dep-manifest.json
           if-no-files-found: error
           retention-days: 30
 
@@ -320,32 +356,80 @@ jobs:
     permissions:
       contents: write
     steps:
-      - name: Download .msi artefact
+      - name: Checkout installer repo (for the notes script)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+          sparse-checkout: |
+            scripts/generate_release_notes.py
+          sparse-checkout-cone-mode: false
+
+      - name: Download current .msi + dep-manifest.json
         uses: actions/download-artifact@v4
         with:
           name: installer-${{ inputs.release_type || 'alpha' }}-${{ github.run_id }}
-          path: msi
+          path: artefact
+
+      - name: Download previous nightly-alpha dep-manifest (if any)
+        id: prev-manifest
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -eu
+          mkdir -p prev
+          if gh release download nightly-alpha \
+              --repo "$GITHUB_REPOSITORY" \
+              --pattern dep-manifest.json \
+              --dir prev 2>/dev/null; then
+              echo "Previous nightly-alpha manifest downloaded"
+              echo "path=prev/dep-manifest.json" >> "$GITHUB_OUTPUT"
+          else
+              echo "::notice::No previous nightly-alpha release found — this will be an initial publish"
+              echo "path=" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Generate dep-change release-notes section
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          python3 scripts/generate_release_notes.py \
+              artefact/dep-manifest.json \
+              "${{ steps.prev-manifest.outputs.path }}" \
+              release-notes-section.md
+
+      - name: Compose full release body
+        run: |
+          cat >release-body.md <<'EOF'
+          **Latest BHoM alpha build.**
+
+          - Build: [#${{ github.run_id }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
+          - Commit: `${{ github.sha }}`
+          - Triggered by: `${{ github.event_name }}`
+
+          Install: download the `.msi`, double-click. Uninstall via Windows
+          "Apps & Features".
+
+          This tag is re-issued on every successful nightly build and on
+          on-demand `workflow_dispatch` runs — bookmark this page for the
+          latest alpha.
+
+          ---
+
+          EOF
+          cat release-notes-section.md >> release-body.md
+          echo ""
+          echo "=== Release body preview (first 80 lines) ==="
+          head -80 release-body.md
 
       - name: Publish / update rolling release
         uses: softprops/action-gh-release@v2
         with:
           tag_name: nightly-alpha
           name: BHoM Alpha (Nightly)
-          body: |
-            **Latest BHoM alpha build.**
-
-            - Build: [#${{ github.run_id }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
-            - Commit: `${{ github.sha }}`
-            - Triggered by: `${{ github.event_name }}`
-            - Built: `${{ github.event.repository.updated_at }}`
-
-            Install: download the `.msi`, double-click. Uninstall via Windows
-            "Apps & Features".
-
-            This tag is re-issued on every successful nightly build and on
-            on-demand `workflow_dispatch` runs — bookmark this page for the
-            latest alpha.
-          files: msi/*.msi
+          body_path: release-body.md
+          files: |
+            artefact/*.msi
+            artefact/dep-manifest.json
           make_latest: false
           prerelease: true
 

--- a/.github/workflows/build-installer.yml
+++ b/.github/workflows/build-installer.yml
@@ -399,13 +399,16 @@ jobs:
         run: |
           set -eu
           mkdir -p prev
-          # List releases, pick the most recent alpha-*/manual-alpha-* whose tag
-          # isn't the one we're about to publish.
+          # List releases, pick the most recent prior alpha-related release.
+          # The 'nightly-alpha$' clause is a one-time bootstrap: the sandbox
+          # already has a release under that tag from an earlier iteration of
+          # this workflow. Once the first new alpha-* release is published we
+          # can safely drop it from the pattern.
           prev_tag=$(gh release list \
               --repo "$GITHUB_REPOSITORY" \
               --limit 50 \
               --json tagName,createdAt \
-              --jq "[.[] | select(.tagName | test(\"^(alpha|manual-alpha)-\")) | select(.tagName != \"$CURRENT_TAG\")] | sort_by(.createdAt) | reverse | .[0].tagName // \"\"")
+              --jq "[.[] | select(.tagName | test(\"^(alpha-|manual-alpha-|nightly-alpha\$)\")) | select(.tagName != \"$CURRENT_TAG\")] | sort_by(.createdAt) | reverse | .[0].tagName // \"\"")
           if [ -n "$prev_tag" ] && gh release download "$prev_tag" \
               --repo "$GITHUB_REPOSITORY" \
               --pattern dep-manifest.json \

--- a/.github/workflows/build-installer.yml
+++ b/.github/workflows/build-installer.yml
@@ -366,12 +366,13 @@ jobs:
     permissions:
       contents: write
     steps:
-      - name: Checkout installer repo (for the notes script)
+      - name: Checkout installer repo (for the release-notes scripts)
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
           sparse-checkout: |
             scripts/generate_release_notes.py
+            scripts/compose-release-body.sh
           sparse-checkout-cone-mode: false
 
       - name: Download current .msi + dep-manifest.json
@@ -432,43 +433,7 @@ jobs:
         env:
           INSTALL_TEST_RESULT: ${{ needs.install-test.result }}
           PREV_TAG:            ${{ steps.prev-manifest.outputs.prev_tag }}
-        run: |
-          set -eu
-          run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
-
-          if [ "$INSTALL_TEST_RESULT" = "success" ]; then
-              test_status="Passed install and uninstall smoke tests on windows-2022 and windows-2025."
-          else
-              test_status="Smoke test result: \`$INSTALL_TEST_RESULT\`. See [run logs]($run_url) for details. This build is provided for diagnostic and local testing only and should not be promoted to users."
-          fi
-
-          if [ -n "$PREV_TAG" ]; then
-              diff_note="Changes are computed against [\`$PREV_TAG\`](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/releases/tag/${PREV_TAG})."
-          else
-              diff_note="No prior alpha release was found, so this build is published as an initial baseline."
-          fi
-
-          cat >release-body.md <<EOF
-          Pre-release build of the BHoM installer produced by the alpha CI pipeline. See the build provenance below before installing.
-
-          ### Build provenance
-
-          | Field | Value |
-          |---|---|
-          | Build | [#${GITHUB_RUN_ID}]($run_url) |
-          | Commit | \`${GITHUB_SHA}\` |
-          | Triggered by | \`${GITHUB_EVENT_NAME}\` |
-          | Test status | $test_status |
-
-          ### Changes
-
-          $diff_note
-
-          EOF
-          cat release-notes-section.md >> release-body.md
-          echo ""
-          echo "=== Release body preview (first 80 lines) ==="
-          head -80 release-body.md
+        run: bash scripts/compose-release-body.sh
 
       - name: Publish release
         uses: softprops/action-gh-release@v2
@@ -494,61 +459,17 @@ jobs:
     permissions:
       issues: write
     steps:
+      - name: Checkout installer repo (for the notify script)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+          sparse-checkout: |
+            scripts/notify-on-failure.sh
+          sparse-checkout-cone-mode: false
+
       - name: Open or update tracking issue
         env:
           GH_TOKEN: ${{ github.token }}
           BUILD_RESULT: ${{ needs.build.result }}
           TEST_RESULT:  ${{ needs.install-test.result }}
-        run: |
-          set -eu
-          today=$(date -u +%Y-%m-%d)
-          title="[CI] Nightly alpha build failed ($today)"
-          run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
-
-          # ALWAYS emit a workflow-page-visible annotation. This is the lower
-          # bound: a failure indicator that's visible regardless of whether
-          # the consumer repo has Issues enabled. The tracking-issue creation
-          # below is an extra signal on top of this.
-          echo "::error title=Nightly alpha build failed::See $run_url"
-
-          # Skip tracking-issue creation if the repo has Issues disabled.
-          # This case surfaced on the sandbox repo when notify-on-failure was
-          # first smoke-tested: gh issue create errors with 'repository has
-          # disabled issues'. The annotation above remains the failure signal.
-          has_issues=$(gh api "repos/$GITHUB_REPOSITORY" --jq '.has_issues // false')
-          if [ "$has_issues" != "true" ]; then
-              echo "::notice::Issues are disabled on $GITHUB_REPOSITORY. Skipping tracking-issue creation; the workflow annotation above remains the failure marker."
-              exit 0
-          fi
-
-          body=$(cat <<EOF
-          The scheduled nightly alpha build failed.
-
-          - **Run:** ${run_url}
-          - **Commit:** \`${GITHUB_SHA}\`
-          - **build job:** \`${BUILD_RESULT}\`
-          - **install-test matrix:** \`${TEST_RESULT}\`
-
-          See the run log for details. This issue auto-opens when a scheduled
-          run fails; close it once the underlying issue is resolved.
-          EOF
-          )
-
-          # Avoid spamming: if an open issue already exists with this exact
-          # title (i.e. another failure already happened today), comment on it
-          # instead of opening a duplicate.
-          existing=$(gh issue list \
-              --repo "$GITHUB_REPOSITORY" \
-              --search "in:title \"$title\"" \
-              --state open \
-              --json number --jq '.[0].number // empty')
-
-          if [ -n "$existing" ]; then
-              gh issue comment "$existing" --repo "$GITHUB_REPOSITORY" --body "$body"
-              echo "Commented on existing issue #$existing"
-          else
-              gh issue create \
-                  --repo "$GITHUB_REPOSITORY" \
-                  --title "$title" \
-                  --body "$body"
-          fi
+        run: bash scripts/notify-on-failure.sh

--- a/.github/workflows/build-installer.yml
+++ b/.github/workflows/build-installer.yml
@@ -85,14 +85,14 @@ jobs:
           # Directory.Build.props at the parent is walked-up by MSBuild for every
           # project under the workspace.
           $propsPath = 'D:\a\BHoM_Installer\Directory.Build.props'
-          $propsContent = @"
-<Project>
-  <PropertyGroup Condition=`" '`$(TargetFrameworkIdentifier)' == '.NETFramework' AND '`$(TargetFrameworkVersion)' == 'v4.0' `">
-    <FrameworkPathOverride>$refPath</FrameworkPathOverride>
-  </PropertyGroup>
-</Project>
-"@
-          Set-Content -Path $propsPath -Value $propsContent -Encoding UTF8
+          $lines = @(
+              '<Project>',
+              '  <PropertyGroup Condition=" ''$(TargetFrameworkIdentifier)'' == ''.NETFramework'' AND ''$(TargetFrameworkVersion)'' == ''v4.0'' ">',
+              "    <FrameworkPathOverride>$refPath</FrameworkPathOverride>",
+              '  </PropertyGroup>',
+              '</Project>'
+          )
+          Set-Content -Path $propsPath -Value $lines -Encoding UTF8
           Write-Host "Wrote $propsPath"
           Write-Host "FrameworkPathOverride (v4.0 only) = $refPath"
 

--- a/.github/workflows/build-installer.yml
+++ b/.github/workflows/build-installer.yml
@@ -487,43 +487,43 @@ jobs:
           echo "name=$name" >> "$GITHUB_OUTPUT"
           echo "::notice::Release tag = $tag"
 
-      - name: Find + download previous dep-manifest (for diff)
-        id: prev-manifest
+      - name: Find canonical anchor
+        id: anchor
         env:
           GH_TOKEN: ${{ github.token }}
-          CURRENT_TAG: ${{ steps.tag.outputs.tag }}
+          RELEASE_TAG: ${{ steps.tag.outputs.tag }}
+        run: bash scripts/find-previous-release.sh "$RELEASE_TAG" >> "$GITHUB_OUTPUT"
+
+      - name: Download anchor's dep-manifest
+        id: prev-manifest
+        if: needs.resolve.outputs.source_branch == 'develop' && steps.anchor.outputs.anchor_kind == 'stable'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ANCHOR_TAG: ${{ steps.anchor.outputs.anchor_tag }}
         run: |
           set -eu
           mkdir -p prev
-          # Most recent prior alpha, beta, or v* release. Sorting by
-          # publishedAt to avoid the createdAt collision quirk where same-day
-          # releases share an underlying-tag-resource timestamp.
-          prev_tag=$(gh release list \
-              --repo "$GITHUB_REPOSITORY" \
-              --limit 50 \
-              --json tagName,publishedAt \
-              --jq "[.[] | select(.tagName | test(\"^(alpha-|beta-|v)\")) | select(.tagName != \"$CURRENT_TAG\")] | sort_by(.publishedAt) | reverse | .[0].tagName // \"\"")
-          if [ -n "$prev_tag" ] && gh release download "$prev_tag" \
+          if gh release download "$ANCHOR_TAG" \
               --repo "$GITHUB_REPOSITORY" \
               --pattern dep-manifest.json \
               --dir prev 2>/dev/null; then
-              echo "::notice::Diffing against previous release: $prev_tag"
+              echo "::notice::Anchoring against $ANCHOR_TAG"
               echo "path=prev/dep-manifest.json" >> "$GITHUB_OUTPUT"
-              echo "prev_tag=$prev_tag"          >> "$GITHUB_OUTPUT"
           else
-              echo "::notice::No prior release with a dep-manifest. Publishing as an initial-baseline release."
-              echo "path="     >> "$GITHUB_OUTPUT"
-              echo "prev_tag=" >> "$GITHUB_OUTPUT"
+              echo "::warning::Could not download dep-manifest from $ANCHOR_TAG; rendering initial-baseline section."
+              echo "path=" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Generate dep-change release-notes section
+        if: needs.resolve.outputs.source_branch == 'develop' && steps.anchor.outputs.anchor_kind == 'stable' && steps.prev-manifest.outputs.path != ''
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           python3 scripts/generate_release_notes.py \
               artefact/dep-manifest.json \
               "${{ steps.prev-manifest.outputs.path }}" \
-              release-notes-section.md
+              release-notes-section.md \
+              "${{ steps.anchor.outputs.anchor_tag }}"
 
       - name: Extract built_at from dep-manifest
         id: built-at
@@ -536,7 +536,9 @@ jobs:
       - name: Compose full release body
         env:
           GH_TOKEN:      ${{ github.token }}
-          PREV_TAG:      ${{ steps.prev-manifest.outputs.prev_tag }}
+          ANCHOR_TAG:    ${{ steps.anchor.outputs.anchor_tag }}
+          ANCHOR_KIND:   ${{ steps.anchor.outputs.anchor_kind }}
+          SOURCE_BRANCH: ${{ needs.resolve.outputs.source_branch }}
           RELEASE_TYPE:  ${{ needs.resolve.outputs.release_type }}
           IS_PRERELEASE: ${{ needs.resolve.outputs.prerelease }}
           BUILT_AT:      ${{ steps.built-at.outputs.value }}

--- a/.github/workflows/build-installer.yml
+++ b/.github/workflows/build-installer.yml
@@ -57,6 +57,21 @@ jobs:
       # BuroHappold_Installer (which bundles private BHE repos), add the
       # mint-dep-token step here.
 
+      - name: Pin WiX Toolset v3.11.2
+        # GHA windows-2025-vs2026 ships WiX v3.14. The v3.14 SfxCA.dll stub
+        # (bundled by MakeSfxCA into InstallerCA.CA.dll) appears to be the
+        # source of "SFXCA: Failed to create temp directory. Error code 5"
+        # on hardened Windows 11 per-user installs. v3.11.2 has been the
+        # long-stable build BHoMBot uses; pinning to that for parity until
+        # we migrate to WiX v5 in Phase 2.
+        run: |
+          choco install wixtoolset --version=3.11.2 --force --allow-downgrade -y --no-progress
+          $wixBin = "C:\Program Files (x86)\WiX Toolset v3.11\bin"
+          if (-not (Test-Path $wixBin)) { throw "WiX 3.11 install did not produce expected path: $wixBin" }
+          "WIX=$($wixBin | Split-Path -Parent)\" | Out-File -FilePath $env:GITHUB_ENV -Append
+          "$wixBin" | Out-File -FilePath $env:GITHUB_PATH -Append
+          & "$wixBin\candle.exe" -? | Select-Object -First 1
+
       - name: Build installer
         id: build
         run: |

--- a/.github/workflows/build-installer.yml
+++ b/.github/workflows/build-installer.yml
@@ -536,8 +536,6 @@ jobs:
       - name: Compose full release body
         env:
           GH_TOKEN:      ${{ github.token }}
-          ANCHOR_TAG:    ${{ steps.anchor.outputs.anchor_tag }}
-          ANCHOR_KIND:   ${{ steps.anchor.outputs.anchor_kind }}
           SOURCE_BRANCH: ${{ needs.resolve.outputs.source_branch }}
           RELEASE_TYPE:  ${{ needs.resolve.outputs.release_type }}
           IS_PRERELEASE: ${{ needs.resolve.outputs.prerelease }}

--- a/.github/workflows/build-installer.yml
+++ b/.github/workflows/build-installer.yml
@@ -52,19 +52,10 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Mint cross-org dependency token
-        id: dep-token
-        uses: BuroHappoldEngineeringAdmin/CI_Toolkit/.github/actions/mint-dep-token@main
-        with:
-          app_id:         ${{ secrets.BHOM_APP_ID }}
-          private_key:    ${{ secrets.BHOM_APP_PRIVATE_KEY }}
-          fallback_token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Configure git to use the minted token
-        run: |
-          # Inject the token at git-config level so subsequent clones authenticate.
-          # Avoids embedding the token in URLs (would land in process listings + repo clones).
-          git config --global url."https://x-access-token:${{ steps.dep-token.outputs.token }}@github.com/".insteadOf "https://github.com/"
+      # No git-auth configuration needed: all repos referenced by the BHoM_Installer
+      # manifests are public BHoM org repos. When this workflow is extended to
+      # BuroHappold_Installer (which bundles private BHE repos), add the
+      # mint-dep-token step here.
 
       - name: Build installer
         id: build
@@ -87,8 +78,3 @@ jobs:
           path: ${{ github.workspace }}/Build/*.msi
           if-no-files-found: error
           retention-days: 30
-
-      - name: Cleanup token config
-        if: always()
-        run: |
-          git config --global --unset url."https://x-access-token:${{ steps.dep-token.outputs.token }}@github.com/".insteadOf 2>$null

--- a/.github/workflows/build-installer.yml
+++ b/.github/workflows/build-installer.yml
@@ -182,3 +182,101 @@ jobs:
           path: ${{ github.workspace }}/Build/*.msi
           if-no-files-found: error
           retention-days: 30
+
+  # Smoke test the produced .msi: install on a vanilla Windows runner, assert
+  # log markers + post-install state, then uninstall and re-assert.
+  #
+  # Catches the class of regressions that won't surface from a successful build
+  # alone (e.g. the WiX 3.14 SfxCA temp-directory failure, broken WiX components,
+  # missing-file references, custom-action runtime exceptions). Runs on
+  # windows-latest rather than the BHE custom image so the environment is closer
+  # to what an end-user would see.
+  install-test:
+    name: Install + uninstall smoke test
+    needs: build
+    runs-on: windows-latest
+    timeout-minutes: 15
+    defaults:
+      run:
+        shell: pwsh
+    steps:
+      - name: Download .msi artefact
+        uses: actions/download-artifact@v4
+        with:
+          name: installer-${{ inputs.release_type || 'alpha' }}-${{ github.run_id }}
+          path: msi
+
+      - name: Install
+        run: |
+          $msi = (Get-Item msi\*.msi | Select-Object -First 1).FullName
+          Write-Host "Installing $msi"
+          $p = Start-Process msiexec -ArgumentList '/i', $msi, '/L*V', 'install.log', '/passive' -Wait -PassThru
+          Write-Host "msiexec /i exit code: $($p.ExitCode)"
+          if ($p.ExitCode -ne 0) { throw "msiexec /i failed with exit $($p.ExitCode)" }
+
+      - name: Validate install
+        run: |
+          # MSI verbose log is UTF-16LE by default. Convert for searchability.
+          Get-Content install.log -Encoding Unicode | Set-Content install.utf8.log -Encoding UTF8
+
+          # Hard fatal markers — any of these means the install completed with a
+          # rolled-back transaction even if the exit code looked OK.
+          $patterns = @(
+              'Return value 3',
+              'MainEngineThread is returning 1603',
+              'SFXCA: Failed',
+              'returned actual error code 1603'
+          )
+          $hits = Select-String -Path install.utf8.log -Pattern $patterns
+          if ($hits) {
+              $hits | ForEach-Object { Write-Host "::error::$($_.Line.Trim())" }
+              throw "Fatal markers found in install log"
+          }
+
+          # File-existence assertions on the things WiX components claim to ship
+          $expected = @(
+              'C:\ProgramData\BHoM\Assemblies\BHoM.dll',
+              'C:\ProgramData\BHoM\Assemblies\BHoM_Engine.dll',
+              'C:\ProgramData\BHoM\GrasshopperPlugin\BH.UI.Grasshopper.gha'
+          )
+          $missing = $expected | Where-Object { -not (Test-Path $_) }
+          if ($missing) {
+              $missing | ForEach-Object { Write-Host "::error::Missing post-install file: $_" }
+              throw "Expected files missing after install"
+          }
+
+          # Registry registration check + capture ProductCode for the uninstall step
+          $reg = Get-ItemProperty 'HKLM:\Software\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\*' -ErrorAction SilentlyContinue |
+                 Where-Object { $_.DisplayName -like 'Buildings and Habitats*' } |
+                 Select-Object -First 1
+          if (-not $reg) { throw "Product not registered in Uninstall registry" }
+          Write-Host "::notice::Installed $($reg.DisplayName) $($reg.DisplayVersion)"
+          "PRODUCT_CODE=$($reg.PSChildName)" | Out-File -FilePath $env:GITHUB_ENV -Append
+
+      - name: Uninstall
+        run: |
+          Write-Host "Uninstalling $env:PRODUCT_CODE"
+          $p = Start-Process msiexec -ArgumentList '/x', $env:PRODUCT_CODE, '/L*V', 'uninstall.log', '/passive' -Wait -PassThru
+          Write-Host "msiexec /x exit code: $($p.ExitCode)"
+          if ($p.ExitCode -ne 0) { throw "msiexec /x failed with exit $($p.ExitCode)" }
+
+      - name: Validate uninstall
+        run: |
+          Get-Content uninstall.log -Encoding Unicode | Set-Content uninstall.utf8.log -Encoding UTF8
+          $still = Get-ItemProperty 'HKLM:\Software\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\*' -ErrorAction SilentlyContinue |
+                   Where-Object { $_.DisplayName -like 'Buildings and Habitats*' }
+          if ($still) { throw "Product still registered in Uninstall registry after /x" }
+          Write-Host "::notice::Uninstall left registry clean"
+
+      - name: Upload install/uninstall logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: install-test-logs-${{ github.run_id }}
+          path: |
+            install.log
+            install.utf8.log
+            uninstall.log
+            uninstall.utf8.log
+          if-no-files-found: warn
+          retention-days: 14

--- a/.github/workflows/build-installer.yml
+++ b/.github/workflows/build-installer.yml
@@ -96,33 +96,6 @@ jobs:
           Write-Host "Wrote $propsPath"
           Write-Host "FrameworkPathOverride (v4.0 only) = $refPath"
 
-      - name: Compute cache key date
-        id: cache-date
-        run: |
-          "today=$(Get-Date -Format yyyy-MM-dd)" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
-
-      - name: Cache BHoM dep clones + ProgramData
-        # Cache the cloned dep repos alongside the installer checkout and the
-        # ProgramData\BHoM staging area where every dep's PostBuildEvent xcopies
-        # its DLLs. With a same-day cache hit:
-        #   - Clone-Repo skips re-cloning (already idempotent on existing .git)
-        #   - MSBuild incremental sees no source changes and short-circuits
-        #   - PostBuildEvents don't fire (no inputs newer than outputs)
-        #   - ProgramData is already populated from the cache
-        # Net: 12-min cold build collapses to ~3-4 min on warm reruns.
-        #
-        # The 'today' date in the key forces a fresh full build at most every
-        # 24h, matching BHoMBot's nightly cadence. No restore-keys / fallback,
-        # so we never use a >1-day-old cache (would risk shipping stale deps).
-        id: deps-cache
-        uses: actions/cache@v4
-        with:
-          path: |
-            D:/a/BHoM_Installer
-            !D:/a/BHoM_Installer/BHoM_Installer
-            C:/ProgramData/BHoM
-          key: bhom-deps-${{ inputs.release_type }}-${{ hashFiles('IncludedRepos/*.txt') }}-${{ steps.cache-date.outputs.today }}
-
       - name: Pin WiX Toolset v3.11.2
         # GHA windows-2025-vs2026 ships WiX v3.14. The v3.14 SfxCA.dll stub
         # (bundled by MakeSfxCA into InstallerCA.CA.dll) appears to be the

--- a/.github/workflows/build-installer.yml
+++ b/.github/workflows/build-installer.yml
@@ -174,6 +174,20 @@ jobs:
 
           & "$env:GITHUB_WORKSPACE\scripts\Build-Installer.ps1" @splat
 
+      - name: Assert .msi size is sane
+        # Catches catastrophic packaging regressions: a tiny .msi means WiX shipped
+        # nearly nothing; a huge one means something is being bundled that shouldn't
+        # be. Current builds land ~46 MB; we use a 30-100 MB envelope to allow
+        # normal growth but trip on order-of-magnitude breakage.
+        run: |
+          $msi = Get-Item '${{ github.workspace }}/Build/*.msi' | Select-Object -First 1
+          if (-not $msi) { throw "No .msi found in ${{ github.workspace }}/Build/" }
+          $mb = [math]::Round($msi.Length / 1MB, 2)
+          Write-Host "::notice::.msi size: $mb MB ($($msi.Name))"
+          if ($mb -lt 30 -or $mb -gt 100) {
+              throw ".msi size $mb MB is outside the 30-100 MB sanity range — possible packaging regression"
+          }
+
       - name: Upload installer artefact
         if: success()
         uses: actions/upload-artifact@v4
@@ -188,13 +202,17 @@ jobs:
   #
   # Catches the class of regressions that won't surface from a successful build
   # alone (e.g. the WiX 3.14 SfxCA temp-directory failure, broken WiX components,
-  # missing-file references, custom-action runtime exceptions). Runs on
-  # windows-latest rather than the BHE custom image so the environment is closer
-  # to what an end-user would see.
+  # missing-file references, custom-action runtime exceptions). Runs as a matrix
+  # across two Windows versions so OS-specific CA / SFXCA divergence shows up.
+  # Explicit runner labels rather than windows-latest for reproducibility.
   install-test:
-    name: Install + uninstall smoke test
+    name: Install + uninstall (${{ matrix.os }})
     needs: build
-    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-2022, windows-2025]
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 15
     defaults:
       run:
@@ -247,12 +265,36 @@ jobs:
           $expected = @(
               'C:\ProgramData\BHoM\Assemblies\BHoM.dll',
               'C:\ProgramData\BHoM\Assemblies\BHoM_Engine.dll',
-              'C:\ProgramData\BHoM\GrasshopperPlugin\BH.UI.Grasshopper.gha'
+              'C:\ProgramData\BHoM\GrasshopperPlugin\BH.UI.Grasshopper.gha',
+              'C:\ProgramData\BHoM\Settings\IncludedDLLs.txt'
           )
           $missing = $expected | Where-Object { -not (Test-Path $_) }
           if ($missing) {
               $missing | ForEach-Object { Write-Host "::error::Missing post-install file: $_" }
               throw "Expected files missing after install"
+          }
+
+          # DLL count assertion: the WiX install must place at least as many DLLs
+          # in Assemblies\ as the build manifest declares. Fewer-than-manifest = WiX
+          # dropped components silently.
+          $manifestEntries = (Get-Content 'C:\ProgramData\BHoM\Settings\IncludedDLLs.txt' | Where-Object { $_.Trim() }).Count
+          $onDiskDlls      = (Get-ChildItem 'C:\ProgramData\BHoM\Assemblies' -Filter '*.dll' -ErrorAction SilentlyContinue).Count
+          Write-Host "::notice::Assemblies on disk: $onDiskDlls    IncludedDLLs.txt manifest: $manifestEntries"
+          if ($onDiskDlls -lt $manifestEntries) {
+              throw "Only $onDiskDlls DLLs installed but manifest declares $manifestEntries — components missing"
+          }
+
+          # BHoM.dll loadability smoke: assembly must be a valid .NET assembly with
+          # a resolvable identity. We deliberately don't call GetTypes() — that
+          # requires every referenced dep to be resolvable in the load context,
+          # which is fragile for a per-file Assembly.LoadFrom. AssemblyName resolution
+          # is enough to catch "build emitted a corrupted DLL" without false fails.
+          try {
+              $asm  = [System.Reflection.Assembly]::LoadFrom('C:\ProgramData\BHoM\Assemblies\BHoM.dll')
+              $name = $asm.GetName()
+              Write-Host "::notice::BHoM.dll loaded: $($name.Name) v$($name.Version)"
+          } catch {
+              throw "BHoM.dll failed to load as a .NET assembly: $($_.Exception.Message)"
           }
 
           # Registry registration check + capture ProductCode for the uninstall step
@@ -282,7 +324,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: install-test-logs-${{ github.run_id }}
+          name: install-test-logs-${{ matrix.os }}-${{ github.run_id }}
           path: |
             install.log
             install.utf8.log

--- a/.github/workflows/build-installer.yml
+++ b/.github/workflows/build-installer.yml
@@ -65,10 +65,12 @@ jobs:
 
           $patchVersion = '${{ inputs.patch_version }}'
 
-          $args = @('-ReleaseType', $releaseType)
-          if ($patchVersion) { $args += @('-PatchVersion', $patchVersion) }
+          # Hashtable splat (not array) so PowerShell binds by parameter name.
+          # Array splatting was treating '-ReleaseType' as a positional value.
+          $splat = @{ ReleaseType = $releaseType }
+          if ($patchVersion) { $splat['PatchVersion'] = $patchVersion }
 
-          & "$env:GITHUB_WORKSPACE\scripts\Build-Installer.ps1" @args
+          & "$env:GITHUB_WORKSPACE\scripts\Build-Installer.ps1" @splat
 
       - name: Upload installer artefact
         if: success()

--- a/.github/workflows/build-installer.yml
+++ b/.github/workflows/build-installer.yml
@@ -219,18 +219,28 @@ jobs:
           # MSI verbose log is UTF-16LE by default. Convert for searchability.
           Get-Content install.log -Encoding Unicode | Set-Content install.utf8.log -Encoding UTF8
 
-          # Hard fatal markers — any of these means the install completed with a
-          # rolled-back transaction even if the exit code looked OK.
+          # Hard fatal markers — any of these means a fatal action / engine
+          # failure that rolled back the transaction. We deliberately do NOT
+          # flag bare 'returned actual error code 1603' lines: WiX marks some
+          # custom actions Continue="yes" (WixRemoveFoldersEx, Action_RegisterAddIn,
+          # Action_UnRegisterAddInOld) and the log records the 1603 followed by
+          # "but will be translated to success due to continue marking" — those
+          # are by-design non-fatal and the real-fatal case still triggers
+          # Return value 3 + MainEngineThread 1603 which the patterns below catch.
           $patterns = @(
               'Return value 3',
               'MainEngineThread is returning 1603',
-              'SFXCA: Failed',
-              'returned actual error code 1603'
+              'SFXCA: Failed'
           )
           $hits = Select-String -Path install.utf8.log -Pattern $patterns
           if ($hits) {
               $hits | ForEach-Object { Write-Host "::error::$($_.Line.Trim())" }
               throw "Fatal markers found in install log"
+          }
+
+          # Positive success check — the engine MUST have logged a clean exit.
+          if (-not (Select-String -Path install.utf8.log -Pattern 'Installation success or error status: 0' -Quiet)) {
+              throw "Install log missing 'Installation success or error status: 0' — install did not complete cleanly"
           }
 
           # File-existence assertions on the things WiX components claim to ship

--- a/.github/workflows/build-installer.yml
+++ b/.github/workflows/build-installer.yml
@@ -21,20 +21,26 @@ on:
   workflow_dispatch:
     inputs:
       release_type:
-        description: 'Release type'
+        description: |
+          alpha — alpha pre-release. Tag: vM.N.P-alpha.YYMMDD[.counter]
+          beta  — beta pre-release (use during feature-freeze QA).
+                  Tag: vM.N.P-beta.counter
+          Final beta releases are produced ONLY by pushing a 'v*' git tag,
+          never via this dispatch.
         type: choice
         options:
           - alpha
           - beta
         default: alpha
-      patch_version:
+      source_branch:
         description: |
-          Patch version. For alpha, blank means today's date (YYMMDD).
-          For beta, blank means '0'; increment only when reissuing a
-          beta release with a hotfix on the same major.minor milestone.
+          Branch to build from. Default 'develop'.
+          Alpha-only: useful for testing a feature branch across deps that
+          share the branch name. Deps without the branch fall back to their
+          default branch. Beta ignores this input and always uses 'develop'.
         type: string
         required: false
-        default: ''
+        default: 'develop'
 
   schedule:
     - cron: '45 0 * * *'   # 00:45 UTC nightly, matching BHoMBot
@@ -46,6 +52,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: build-installer-${{ github.event_name }}
+  cancel-in-progress: false
+
 jobs:
   # Normalise the trigger event into the parameters every downstream job
   # needs. Single source of truth for: which release type to build, what
@@ -55,81 +65,33 @@ jobs:
     name: Resolve release parameters
     runs-on: ubuntu-latest
     outputs:
-      release_type:  ${{ steps.r.outputs.release_type }}
-      patch_version: ${{ steps.r.outputs.patch_version }}
-      main_branch:   ${{ steps.r.outputs.main_branch }}
-      prerelease:    ${{ steps.r.outputs.prerelease }}
-      make_latest:   ${{ steps.r.outputs.make_latest }}
-      release_tag:   ${{ steps.r.outputs.release_tag }}
+      release_type:      ${{ steps.r.outputs.release_type }}
+      source_branch:     ${{ steps.r.outputs.source_branch }}
+      prerelease:        ${{ steps.r.outputs.prerelease }}
+      make_latest:       ${{ steps.r.outputs.make_latest }}
+      release_tag:       ${{ steps.r.outputs.release_tag }}
+      msi_patch_version: ${{ steps.r.outputs.msi_patch_version }}
     steps:
+      - name: Checkout (sparse) for the wixproj and resolve script
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+          sparse-checkout: |
+            BHoM_Installer/BHoM_Installer.wixproj
+            scripts/resolve-release-tag.sh
+          sparse-checkout-cone-mode: false
+
       - id: r
         shell: bash
         env:
+          GH_TOKEN: ${{ github.token }}
           INPUT_RELEASE_TYPE:  ${{ inputs.release_type }}
-          INPUT_PATCH_VERSION: ${{ inputs.patch_version }}
+          INPUT_SOURCE_BRANCH: ${{ inputs.source_branch }}
         run: |
-          set -eu
-
-          case "$GITHUB_EVENT_NAME" in
-            schedule)
-              release_type=alpha
-              patch_version=""        # Build-Installer.ps1 defaults to today (YYMMDD)
-              main_branch=develop
-              prerelease=true
-              make_latest=false
-              release_tag=""          # publish step composes 'alpha-{YYYYMMDD-HHMMSS}'
-              ;;
-
-            workflow_dispatch)
-              release_type="${INPUT_RELEASE_TYPE:-alpha}"
-              patch_version="$INPUT_PATCH_VERSION"
-              main_branch=develop     # dispatch builds always track develop tip
-              prerelease=true
-              make_latest=false
-              release_tag=""          # publish step composes a timestamped tag
-              ;;
-
-            push)
-              # Tag push 'v*'. Tag schema mirrors BHoMBot's beta convention:
-              # v{major}.{minor}.{patch} where patch defaults to 0 and is the
-              # hotfix counter within the major.minor milestone.
-              release_type=beta
-              main_branch=main        # deps build against main, matching the tag
-              prerelease=false
-              make_latest=true
-              release_tag="$GITHUB_REF_NAME"
-
-              # Extract the patch component from the tag. Expected forms
-              # (any non-numeric suffix is ignored so semver pre-release
-              # identifiers and ad-hoc test suffixes both parse cleanly):
-              #   v9.2          -> patch 0
-              #   v9.2.0        -> patch 0
-              #   v9.2.1        -> patch 1
-              #   v9.2.0-rc.1   -> patch 0
-              #   v9.2.0-test   -> patch 0
-              ver="${GITHUB_REF_NAME#v}"
-              if [[ "$ver" =~ ^[0-9]+\.[0-9]+(\.([0-9]+))? ]]; then
-                  patch_version="${BASH_REMATCH[2]:-0}"
-              else
-                  echo "::warning::Tag '$GITHUB_REF_NAME' does not match v{major}.{minor}[.{patch}]; using patch_version=0"
-                  patch_version=0
-              fi
-              ;;
-
-            *)
-              echo "::error::Unsupported event '$GITHUB_EVENT_NAME'"
-              exit 1
-              ;;
-          esac
-
-          echo "release_type=$release_type"   >> "$GITHUB_OUTPUT"
-          echo "patch_version=$patch_version" >> "$GITHUB_OUTPUT"
-          echo "main_branch=$main_branch"     >> "$GITHUB_OUTPUT"
-          echo "prerelease=$prerelease"       >> "$GITHUB_OUTPUT"
-          echo "make_latest=$make_latest"     >> "$GITHUB_OUTPUT"
-          echo "release_tag=$release_tag"     >> "$GITHUB_OUTPUT"
-
-          echo "::notice::release_type=$release_type, patch_version='$patch_version', main_branch=$main_branch, prerelease=$prerelease, release_tag='$release_tag'"
+          set -euo pipefail
+          bash scripts/resolve-release-tag.sh >> "$GITHUB_OUTPUT"
+          echo "::notice::Resolved parameters:"
+          grep -E '^(release_type|source_branch|prerelease|make_latest|release_tag|msi_patch_version)=' "$GITHUB_OUTPUT"
 
   build:
     name: Build ${{ needs.resolve.outputs.release_type }} installer
@@ -229,17 +191,21 @@ jobs:
       - name: Build installer
         id: build
         env:
-          RELEASE_TYPE:  ${{ needs.resolve.outputs.release_type }}
-          PATCH_VERSION: ${{ needs.resolve.outputs.patch_version }}
-          MAIN_BRANCH:   ${{ needs.resolve.outputs.main_branch }}
+          RELEASE_TYPE:      ${{ needs.resolve.outputs.release_type }}
+          MSI_PATCH_VERSION: ${{ needs.resolve.outputs.msi_patch_version }}
+          SOURCE_BRANCH:     ${{ needs.resolve.outputs.source_branch }}
         run: |
           # Hashtable splat (not array) so PowerShell binds by parameter name.
           # Array splatting would otherwise treat '-ReleaseType' as a value.
           $splat = @{
               ReleaseType = $env:RELEASE_TYPE
-              MainBranch  = $env:MAIN_BRANCH
+              MainBranch  = $env:SOURCE_BRANCH
           }
-          if ($env:PATCH_VERSION) { $splat['PatchVersion'] = $env:PATCH_VERSION }
+          # Only forward MSI_PATCH_VERSION when resolve emitted one. Alpha
+          # leaves it blank so Build-Installer.ps1 falls through to its yyMMdd
+          # default (line 68-70). Beta-pre-release and beta-release flavours
+          # set it explicitly so the MSI filename matches the release tag.
+          if ($env:MSI_PATCH_VERSION) { $splat['PatchVersion'] = $env:MSI_PATCH_VERSION }
 
           & "$env:GITHUB_WORKSPACE\scripts\Build-Installer.ps1" @splat
 
@@ -251,7 +217,7 @@ jobs:
         # release notes.
         env:
           RELEASE_TYPE: ${{ needs.resolve.outputs.release_type }}
-          MAIN_BRANCH:  ${{ needs.resolve.outputs.main_branch }}
+          SOURCE_BRANCH:  ${{ needs.resolve.outputs.source_branch }}
         run: |
           $depsObject = [ordered]@{}
           Get-ChildItem 'D:\a\BHoM_Installer' -Directory -ErrorAction SilentlyContinue |
@@ -263,7 +229,7 @@ jobs:
                       $orgRepo = "$($Matches[1])/$($Matches[2])"
                       $sha = (git -C $_.FullName rev-parse HEAD 2>$null).Trim()
                       if ($sha) {
-                          $depsObject[$orgRepo] = [ordered]@{ branch = $env:MAIN_BRANCH; sha = $sha }
+                          $depsObject[$orgRepo] = [ordered]@{ branch = $env:SOURCE_BRANCH; sha = $sha }
                       }
                   }
               }
@@ -272,7 +238,7 @@ jobs:
               version       = 1
               built_at      = (Get-Date).ToUniversalTime().ToString('o')
               release_type  = $env:RELEASE_TYPE
-              main_branch   = $env:MAIN_BRANCH
+              source_branch = $env:SOURCE_BRANCH
               deps          = $depsObject
           }
 
@@ -559,12 +525,21 @@ jobs:
               "${{ steps.prev-manifest.outputs.path }}" \
               release-notes-section.md
 
+      - name: Extract built_at from dep-manifest
+        id: built-at
+        run: |
+          set -eu
+          built_at=$(jq -r '.built_at' artefact/dep-manifest.json)
+          [ -n "$built_at" ] && [ "$built_at" != "null" ] || { echo "::error::built_at missing from dep-manifest.json"; exit 1; }
+          echo "value=$built_at" >> "$GITHUB_OUTPUT"
+
       - name: Compose full release body
         env:
           GH_TOKEN:      ${{ github.token }}
           PREV_TAG:      ${{ steps.prev-manifest.outputs.prev_tag }}
           RELEASE_TYPE:  ${{ needs.resolve.outputs.release_type }}
           IS_PRERELEASE: ${{ needs.resolve.outputs.prerelease }}
+          BUILT_AT:      ${{ steps.built-at.outputs.value }}
         run: bash scripts/compose-release-body.sh
 
       - name: Publish release

--- a/.github/workflows/build-installer.yml
+++ b/.github/workflows/build-installer.yml
@@ -1,14 +1,19 @@
 # Build Installer. GitHub Actions replacement for BHoMBot's 00:45 UTC alpha build.
 #
-# Triggers:
-#   schedule           Nightly 00:45 UTC, fires on the default branch only.
-#                      Schedule events do not pass workflow inputs, so the
-#                      build defaults to release_type=alpha (handled in
-#                      Build-Installer.ps1 via 'inputs.release_type || alpha').
-#   workflow_dispatch  Manual run for iteration and ad-hoc test builds.
+# Triggers and the release flavours they produce (all parameters resolved by
+# the 'resolve' job below):
 #
-# Trigger to be added later:
-#   push: tags v*      Phase 2+, tagged release builds for beta-test and stable.
+#   schedule            Nightly alpha. Fires 00:45 UTC on the default branch
+#                       only. release_type=alpha, prerelease=true.
+#
+#   workflow_dispatch   Manual run. The 'release_type' input chooses alpha or
+#                       beta; beta is intended for use during a feature-freeze
+#                       window. prerelease=true in both cases.
+#
+#   push: tags 'v*'     Finalised release. The tag (e.g. v9.2.0) is pushed to
+#                       the default branch after a develop -> main merge.
+#                       release_type=beta, prerelease=false, marked as the
+#                       Latest release on the Releases page.
 
 name: Build Installer
 
@@ -23,7 +28,10 @@ on:
           - beta
         default: alpha
       patch_version:
-        description: 'Patch version (yyMMdd). Blank = today.'
+        description: |
+          Patch version. For alpha, blank means today's date (YYMMDD).
+          For beta, blank means '0'; increment only when reissuing a
+          beta release with a hotfix on the same major.minor milestone.
         type: string
         required: false
         default: ''
@@ -31,12 +39,101 @@ on:
   schedule:
     - cron: '45 0 * * *'   # 00:45 UTC nightly, matching BHoMBot
 
+  push:
+    tags:
+      - 'v*'
+
 permissions:
   contents: read
 
 jobs:
+  # Normalise the trigger event into the parameters every downstream job
+  # needs. Single source of truth for: which release type to build, what
+  # patch version to pass to MSBuild, what branch each dep should be
+  # cloned from, and how the GitHub Release should be flagged.
+  resolve:
+    name: Resolve release parameters
+    runs-on: ubuntu-latest
+    outputs:
+      release_type:  ${{ steps.r.outputs.release_type }}
+      patch_version: ${{ steps.r.outputs.patch_version }}
+      main_branch:   ${{ steps.r.outputs.main_branch }}
+      prerelease:    ${{ steps.r.outputs.prerelease }}
+      make_latest:   ${{ steps.r.outputs.make_latest }}
+      release_tag:   ${{ steps.r.outputs.release_tag }}
+    steps:
+      - id: r
+        shell: bash
+        env:
+          INPUT_RELEASE_TYPE:  ${{ inputs.release_type }}
+          INPUT_PATCH_VERSION: ${{ inputs.patch_version }}
+        run: |
+          set -eu
+
+          case "$GITHUB_EVENT_NAME" in
+            schedule)
+              release_type=alpha
+              patch_version=""        # Build-Installer.ps1 defaults to today (YYMMDD)
+              main_branch=develop
+              prerelease=true
+              make_latest=false
+              release_tag=""          # publish step composes 'alpha-{YYYYMMDD-HHMMSS}'
+              ;;
+
+            workflow_dispatch)
+              release_type="${INPUT_RELEASE_TYPE:-alpha}"
+              patch_version="$INPUT_PATCH_VERSION"
+              main_branch=develop     # dispatch builds always track develop tip
+              prerelease=true
+              make_latest=false
+              release_tag=""          # publish step composes a timestamped tag
+              ;;
+
+            push)
+              # Tag push 'v*'. Tag schema mirrors BHoMBot's beta convention:
+              # v{major}.{minor}.{patch} where patch defaults to 0 and is the
+              # hotfix counter within the major.minor milestone.
+              release_type=beta
+              main_branch=main        # deps build against main, matching the tag
+              prerelease=false
+              make_latest=true
+              release_tag="$GITHUB_REF_NAME"
+
+              # Extract the patch component from the tag. Expected forms
+              # (any non-numeric suffix is ignored so semver pre-release
+              # identifiers and ad-hoc test suffixes both parse cleanly):
+              #   v9.2          -> patch 0
+              #   v9.2.0        -> patch 0
+              #   v9.2.1        -> patch 1
+              #   v9.2.0-rc.1   -> patch 0
+              #   v9.2.0-test   -> patch 0
+              ver="${GITHUB_REF_NAME#v}"
+              if [[ "$ver" =~ ^[0-9]+\.[0-9]+(\.([0-9]+))? ]]; then
+                  patch_version="${BASH_REMATCH[2]:-0}"
+              else
+                  echo "::warning::Tag '$GITHUB_REF_NAME' does not match v{major}.{minor}[.{patch}]; using patch_version=0"
+                  patch_version=0
+              fi
+              ;;
+
+            *)
+              echo "::error::Unsupported event '$GITHUB_EVENT_NAME'"
+              exit 1
+              ;;
+          esac
+
+          echo "release_type=$release_type"   >> "$GITHUB_OUTPUT"
+          echo "patch_version=$patch_version" >> "$GITHUB_OUTPUT"
+          echo "main_branch=$main_branch"     >> "$GITHUB_OUTPUT"
+          echo "prerelease=$prerelease"       >> "$GITHUB_OUTPUT"
+          echo "make_latest=$make_latest"     >> "$GITHUB_OUTPUT"
+          echo "release_tag=$release_tag"     >> "$GITHUB_OUTPUT"
+
+          echo "::notice::release_type=$release_type, patch_version='$patch_version', main_branch=$main_branch, prerelease=$prerelease, release_tag='$release_tag'"
+
   build:
-    name: Build ${{ inputs.release_type || 'alpha' }} installer
+    name: Build ${{ needs.resolve.outputs.release_type }} installer
+    needs: resolve
     runs-on: windows-2025-vs2026
     timeout-minutes: 180   # generous; tighten once we know real duration
     defaults:
@@ -131,16 +228,18 @@ jobs:
 
       - name: Build installer
         id: build
+        env:
+          RELEASE_TYPE:  ${{ needs.resolve.outputs.release_type }}
+          PATCH_VERSION: ${{ needs.resolve.outputs.patch_version }}
+          MAIN_BRANCH:   ${{ needs.resolve.outputs.main_branch }}
         run: |
-          $releaseType = '${{ inputs.release_type }}'
-          if (-not $releaseType) { $releaseType = 'alpha' }
-
-          $patchVersion = '${{ inputs.patch_version }}'
-
           # Hashtable splat (not array) so PowerShell binds by parameter name.
-          # Array splatting was treating '-ReleaseType' as a positional value.
-          $splat = @{ ReleaseType = $releaseType }
-          if ($patchVersion) { $splat['PatchVersion'] = $patchVersion }
+          # Array splatting would otherwise treat '-ReleaseType' as a value.
+          $splat = @{
+              ReleaseType = $env:RELEASE_TYPE
+              MainBranch  = $env:MAIN_BRANCH
+          }
+          if ($env:PATCH_VERSION) { $splat['PatchVersion'] = $env:PATCH_VERSION }
 
           & "$env:GITHUB_WORKSPACE\scripts\Build-Installer.ps1" @splat
 
@@ -151,7 +250,8 @@ jobs:
         # and diffs it against this one to render "what changed since last build"
         # release notes.
         env:
-          RELEASE_TYPE: ${{ inputs.release_type || 'alpha' }}
+          RELEASE_TYPE: ${{ needs.resolve.outputs.release_type }}
+          MAIN_BRANCH:  ${{ needs.resolve.outputs.main_branch }}
         run: |
           $depsObject = [ordered]@{}
           Get-ChildItem 'D:\a\BHoM_Installer' -Directory -ErrorAction SilentlyContinue |
@@ -163,7 +263,7 @@ jobs:
                       $orgRepo = "$($Matches[1])/$($Matches[2])"
                       $sha = (git -C $_.FullName rev-parse HEAD 2>$null).Trim()
                       if ($sha) {
-                          $depsObject[$orgRepo] = [ordered]@{ branch = 'develop'; sha = $sha }
+                          $depsObject[$orgRepo] = [ordered]@{ branch = $env:MAIN_BRANCH; sha = $sha }
                       }
                   }
               }
@@ -172,7 +272,7 @@ jobs:
               version       = 1
               built_at      = (Get-Date).ToUniversalTime().ToString('o')
               release_type  = $env:RELEASE_TYPE
-              main_branch   = 'develop'
+              main_branch   = $env:MAIN_BRANCH
               deps          = $depsObject
           }
 
@@ -198,7 +298,7 @@ jobs:
         if: success()
         uses: actions/upload-artifact@v4
         with:
-          name: installer-${{ inputs.release_type || 'alpha' }}-${{ github.run_id }}
+          name: installer-${{ needs.resolve.outputs.release_type }}-${{ github.run_id }}
           path: |
             ${{ github.workspace }}/Build/*.msi
             ${{ github.workspace }}/Build/dep-manifest.json
@@ -215,7 +315,7 @@ jobs:
   # Explicit runner labels rather than windows-latest for reproducibility.
   install-test:
     name: Install + uninstall (${{ matrix.os }})
-    needs: build
+    needs: [resolve, build]
     strategy:
       fail-fast: false
       matrix:
@@ -229,7 +329,7 @@ jobs:
       - name: Download .msi artefact
         uses: actions/download-artifact@v4
         with:
-          name: installer-${{ inputs.release_type || 'alpha' }}-${{ github.run_id }}
+          name: installer-${{ needs.resolve.outputs.release_type }}-${{ github.run_id }}
           path: msi
 
       - name: Install
@@ -356,25 +456,23 @@ jobs:
           if-no-files-found: warn
           retention-days: 14
 
-  # Publish the .msi as a preserved per-build Release. Single tag scheme for
-  # both triggers:
-  #   alpha-{YYYYMMDD-HHMMSS}
-  # The 'Triggered by:' line in the release body distinguishes scheduled
-  # nightlies from manual dispatches; there is no need to encode that in the
-  # tag itself. Each release is preserved (no rolling tag, no overwrite) and
-  # history accumulates indefinitely.
+  # Publish the .msi as a preserved per-build GitHub Release. The flavour
+  # is determined by what triggered the run, normalised in the resolve job:
   #
-  # Gated on the entire pipeline succeeding (build + install-test). Failed
-  # builds do not appear on the Releases page. The .msi remains accessible
-  # from the workflow run's "Upload installer artefact" Actions artifact for
-  # local debugging when smoke tests fail.
-  publish-alpha:
-    name: Publish alpha release
-    needs: [build, install-test]
-    if: |
-      success() &&
-      (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') &&
-      (inputs.release_type == 'alpha' || inputs.release_type == null || inputs.release_type == '')
+  #   schedule        alpha       prerelease=true   tag = alpha-{YYYYMMDD-HHMMSS}
+  #   dispatch alpha  alpha       prerelease=true   tag = alpha-{YYYYMMDD-HHMMSS}
+  #   dispatch beta   beta        prerelease=true   tag = beta-{YYYYMMDD-HHMMSS}
+  #   push v*         beta        prerelease=false  tag = the git tag (e.g. v9.2.0), marked Latest
+  #
+  # Each release is preserved (no rolling tag, no overwrite). History
+  # accumulates indefinitely. Gated on the entire pipeline succeeding
+  # (build + install-test). Failed builds do not appear on the Releases
+  # page; the .msi is still accessible from the workflow run's
+  # "Upload installer artefact" Actions artifact for local debugging.
+  publish:
+    name: Publish ${{ needs.resolve.outputs.release_type }} release
+    needs: [resolve, build, install-test]
+    if: success()
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -392,21 +490,38 @@ jobs:
       - name: Download current .msi + dep-manifest.json
         uses: actions/download-artifact@v4
         with:
-          name: installer-${{ inputs.release_type || 'alpha' }}-${{ github.run_id }}
+          name: installer-${{ needs.resolve.outputs.release_type }}-${{ github.run_id }}
           path: artefact
 
       - name: Compute release tag and name
         id: tag
         shell: bash
+        env:
+          RESOLVED_TAG:  ${{ needs.resolve.outputs.release_tag }}
+          RELEASE_TYPE:  ${{ needs.resolve.outputs.release_type }}
         run: |
           set -eu
-          tag="alpha-$(date -u +%Y%m%d-%H%M%S)"
-          name="BHoM Alpha Installer ($(date -u +'%Y-%m-%d %H:%M:%S') UTC)"
+          if [ -n "$RESOLVED_TAG" ]; then
+              # Tag-push event: reuse the git tag as the release tag.
+              tag="$RESOLVED_TAG"
+              name="BHoM ${RESOLVED_TAG} Release"
+          else
+              # Schedule or dispatch: compose a timestamped tag from the
+              # release type.
+              ts=$(date -u +%Y%m%d-%H%M%S)
+              tag="${RELEASE_TYPE}-${ts}"
+              case "$RELEASE_TYPE" in
+                  alpha) human="Alpha Installer" ;;
+                  beta)  human="Beta Installer" ;;
+                  *)     human="${RELEASE_TYPE^} Installer" ;;
+              esac
+              name="BHoM ${human} ($(date -u +'%Y-%m-%d %H:%M:%S') UTC)"
+          fi
           echo "tag=$tag"   >> "$GITHUB_OUTPUT"
           echo "name=$name" >> "$GITHUB_OUTPUT"
           echo "::notice::Release tag = $tag"
 
-      - name: Find + download most recent prior alpha dep-manifest (for diff)
+      - name: Find + download previous dep-manifest (for diff)
         id: prev-manifest
         env:
           GH_TOKEN: ${{ github.token }}
@@ -414,13 +529,14 @@ jobs:
         run: |
           set -eu
           mkdir -p prev
-          # Most recent prior alpha release. Tag scheme is alpha-{timestamp},
-          # so a single anchored prefix is sufficient.
+          # Most recent prior alpha, beta, or v* release. Sorting by
+          # publishedAt to avoid the createdAt collision quirk where same-day
+          # releases share an underlying-tag-resource timestamp.
           prev_tag=$(gh release list \
               --repo "$GITHUB_REPOSITORY" \
               --limit 50 \
               --json tagName,publishedAt \
-              --jq "[.[] | select(.tagName | test(\"^alpha-\")) | select(.tagName != \"$CURRENT_TAG\")] | sort_by(.publishedAt) | reverse | .[0].tagName // \"\"")
+              --jq "[.[] | select(.tagName | test(\"^(alpha-|beta-|v)\")) | select(.tagName != \"$CURRENT_TAG\")] | sort_by(.publishedAt) | reverse | .[0].tagName // \"\"")
           if [ -n "$prev_tag" ] && gh release download "$prev_tag" \
               --repo "$GITHUB_REPOSITORY" \
               --pattern dep-manifest.json \
@@ -429,7 +545,7 @@ jobs:
               echo "path=prev/dep-manifest.json" >> "$GITHUB_OUTPUT"
               echo "prev_tag=$prev_tag"          >> "$GITHUB_OUTPUT"
           else
-              echo "::notice::No prior alpha release with a manifest. This will be an initial-baseline publish."
+              echo "::notice::No prior release with a dep-manifest. Publishing as an initial-baseline release."
               echo "path="     >> "$GITHUB_OUTPUT"
               echo "prev_tag=" >> "$GITHUB_OUTPUT"
           fi
@@ -445,30 +561,36 @@ jobs:
 
       - name: Compose full release body
         env:
-          GH_TOKEN: ${{ github.token }}
-          PREV_TAG: ${{ steps.prev-manifest.outputs.prev_tag }}
+          GH_TOKEN:      ${{ github.token }}
+          PREV_TAG:      ${{ steps.prev-manifest.outputs.prev_tag }}
+          RELEASE_TYPE:  ${{ needs.resolve.outputs.release_type }}
+          IS_PRERELEASE: ${{ needs.resolve.outputs.prerelease }}
         run: bash scripts/compose-release-body.sh
 
       - name: Publish release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ steps.tag.outputs.tag }}
-          name: ${{ steps.tag.outputs.name }}
-          body_path: release-body.md
+          tag_name:    ${{ steps.tag.outputs.tag }}
+          name:        ${{ steps.tag.outputs.name }}
+          body_path:   release-body.md
           files: |
             artefact/*.msi
             artefact/dep-manifest.json
-          make_latest: false
-          prerelease: true
+          make_latest: ${{ needs.resolve.outputs.make_latest }}
+          prerelease:  ${{ needs.resolve.outputs.prerelease }}
 
-  # Open a GitHub Issue when a scheduled nightly fails so the breakage does
-  # not rot silently overnight. Only fires on schedule events (not on
-  # dispatch, on the grounds that the human triggering a dispatch is already
-  # aware of the run).
+  # Open a GitHub Issue when a non-interactive build fails, so the breakage
+  # does not rot silently. Fires on:
+  #   schedule           Scheduled nightly. Nobody is watching at 00:45 UTC.
+  #   push (tag v*)      Release publish. A failed release tag is at least as
+  #                      important as a failed nightly; the release coordinator
+  #                      tagged and expects it to succeed.
+  # Does NOT fire on workflow_dispatch failures: the human who triggered the
+  # run is already watching the Actions tab.
   notify-on-failure:
-    name: Open issue on failed nightly
+    name: Open issue on failed scheduled or tagged build
     needs: [build, install-test]
-    if: failure() && github.event_name == 'schedule'
+    if: failure() && (github.event_name == 'schedule' || github.event_name == 'push')
     runs-on: ubuntu-latest
     permissions:
       issues: write

--- a/.github/workflows/build-installer.yml
+++ b/.github/workflows/build-installer.yml
@@ -240,20 +240,25 @@ jobs:
           Write-Host "msiexec /i exit code: $($p.ExitCode)"
           if ($p.ExitCode -ne 0) { throw "msiexec /i failed with exit $($p.ExitCode)" }
 
-      - name: Validate install
+      # The install assertions below are split into one step per check so that
+      # failure attribution is immediate from the GHA Actions UI without log
+      # reading. Each step runs independently; a failed step does NOT skip
+      # subsequent steps (the matrix leg still bails because the failed step
+      # fails the job, but every assertion that ran is visible).
+
+      - name: Convert install log to UTF-8 (MSI logs are UTF-16LE)
         run: |
-          # MSI verbose log is UTF-16LE by default. Convert for searchability.
           Get-Content install.log -Encoding Unicode | Set-Content install.utf8.log -Encoding UTF8
 
-          # Hard fatal markers. Any of these indicates a fatal action or
-          # engine failure that rolled back the transaction. Bare
-          # 'returned actual error code 1603' lines are deliberately not
-          # flagged: WiX marks some custom actions with Continue="yes"
-          # (WixRemoveFoldersEx, Action_RegisterAddIn, Action_UnRegisterAddInOld).
-          # The log records the 1603 followed by "but will be translated to
-          # success due to continue marking", which is by-design non-fatal.
-          # The genuinely-fatal case still produces 'Return value 3' and
-          # 'MainEngineThread is returning 1603', which the patterns below catch.
+      - name: Assert no fatal markers in install log
+        # Bare 'returned actual error code 1603' lines are deliberately not
+        # flagged: WiX marks some custom actions with Continue="yes"
+        # (WixRemoveFoldersEx, Action_RegisterAddIn, Action_UnRegisterAddInOld)
+        # and the log records the 1603 followed by 'but will be translated to
+        # success due to continue marking', which is by-design non-fatal. The
+        # genuinely-fatal case still produces 'Return value 3' and
+        # 'MainEngineThread is returning 1603', which the patterns below catch.
+        run: |
           $patterns = @(
               'Return value 3',
               'MainEngineThread is returning 1603',
@@ -265,12 +270,14 @@ jobs:
               throw "Fatal markers found in install log"
           }
 
-          # Positive success check. The engine must have logged a clean exit.
+      - name: Assert positive install-success marker
+        run: |
           if (-not (Select-String -Path install.utf8.log -Pattern 'Installation success or error status: 0' -Quiet)) {
               throw "Install log missing 'Installation success or error status: 0'. Install did not complete cleanly."
           }
 
-          # File-existence assertions on the things WiX components claim to ship
+      - name: Assert expected files exist after install
+        run: |
           $expected = @(
               'C:\ProgramData\BHoM\Assemblies\BHoM.dll',
               'C:\ProgramData\BHoM\Assemblies\BHoM_Engine.dll',
@@ -283,9 +290,11 @@ jobs:
               throw "Expected files missing after install"
           }
 
-          # DLL count assertion: the WiX install must place at least as many DLLs
-          # in Assemblies\ as the build manifest declares. Fewer-than-manifest = WiX
-          # dropped components silently.
+      - name: Assert installed DLL count meets manifest
+        # The WiX install must place at least as many DLLs in Assemblies\ as
+        # the build manifest declares. Fewer-than-manifest implies WiX dropped
+        # components silently during packaging.
+        run: |
           $manifestEntries = (Get-Content 'C:\ProgramData\BHoM\Settings\IncludedDLLs.txt' | Where-Object { $_.Trim() }).Count
           $onDiskDlls      = (Get-ChildItem 'C:\ProgramData\BHoM\Assemblies' -Filter '*.dll' -ErrorAction SilentlyContinue).Count
           Write-Host "::notice::Assemblies on disk: $onDiskDlls    IncludedDLLs.txt manifest: $manifestEntries"
@@ -293,12 +302,13 @@ jobs:
               throw "Only $onDiskDlls DLLs installed but manifest declares $manifestEntries. Components are missing."
           }
 
-          # BHoM.dll loadability smoke: assembly must be a valid .NET assembly
-          # with a resolvable identity. GetTypes() is deliberately not called
-          # because it requires every referenced dep to be resolvable in the
-          # load context, which is fragile for a per-file Assembly.LoadFrom.
-          # AssemblyName resolution is enough to catch a corrupted-DLL build
-          # without introducing false failures.
+      - name: Assert BHoM.dll loads as a .NET assembly
+        # GetTypes() is deliberately not called because it requires every
+        # referenced dep to be resolvable in the load context, which is
+        # fragile for a per-file Assembly.LoadFrom. AssemblyName resolution
+        # is enough to catch a corrupted-DLL build without introducing false
+        # failures.
+        run: |
           try {
               $asm  = [System.Reflection.Assembly]::LoadFrom('C:\ProgramData\BHoM\Assemblies\BHoM.dll')
               $name = $asm.GetName()
@@ -307,7 +317,10 @@ jobs:
               throw "BHoM.dll failed to load as a .NET assembly: $($_.Exception.Message)"
           }
 
-          # Registry registration check + capture ProductCode for the uninstall step
+      - name: Assert product is registered in Uninstall registry
+        # Also captures the ProductCode into GITHUB_ENV for the subsequent
+        # Uninstall step to use.
+        run: |
           $reg = Get-ItemProperty 'HKLM:\Software\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\*' -ErrorAction SilentlyContinue |
                  Where-Object { $_.DisplayName -like 'Buildings and Habitats*' } |
                  Select-Object -First 1
@@ -365,6 +378,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      actions: read     # for the per-OS Test results table in the release body
     steps:
       - name: Checkout installer repo (for the release-notes scripts)
         uses: actions/checkout@v4
@@ -405,8 +419,8 @@ jobs:
           prev_tag=$(gh release list \
               --repo "$GITHUB_REPOSITORY" \
               --limit 50 \
-              --json tagName,createdAt \
-              --jq "[.[] | select(.tagName | test(\"^alpha-\")) | select(.tagName != \"$CURRENT_TAG\")] | sort_by(.createdAt) | reverse | .[0].tagName // \"\"")
+              --json tagName,publishedAt \
+              --jq "[.[] | select(.tagName | test(\"^alpha-\")) | select(.tagName != \"$CURRENT_TAG\")] | sort_by(.publishedAt) | reverse | .[0].tagName // \"\"")
           if [ -n "$prev_tag" ] && gh release download "$prev_tag" \
               --repo "$GITHUB_REPOSITORY" \
               --pattern dep-manifest.json \
@@ -431,8 +445,8 @@ jobs:
 
       - name: Compose full release body
         env:
-          INSTALL_TEST_RESULT: ${{ needs.install-test.result }}
-          PREV_TAG:            ${{ steps.prev-manifest.outputs.prev_tag }}
+          GH_TOKEN: ${{ github.token }}
+          PREV_TAG: ${{ steps.prev-manifest.outputs.prev_tag }}
         run: bash scripts/compose-release-body.sh
 
       - name: Publish release

--- a/.github/workflows/build-installer.yml
+++ b/.github/workflows/build-installer.yml
@@ -65,12 +65,33 @@ jobs:
         # long-stable build BHoMBot uses; pinning to that for parity until
         # we migrate to WiX v5 in Phase 2.
         run: |
-          choco install wixtoolset --version=3.11.2 --force --allow-downgrade -y --no-progress
-          $wixBin = "C:\Program Files (x86)\WiX Toolset v3.11\bin"
-          if (-not (Test-Path $wixBin)) { throw "WiX 3.11 install did not produce expected path: $wixBin" }
-          "WIX=$($wixBin | Split-Path -Parent)\" | Out-File -FilePath $env:GITHUB_ENV -Append
-          "$wixBin" | Out-File -FilePath $env:GITHUB_PATH -Append
-          & "$wixBin\candle.exe" -? | Select-Object -First 1
+          Write-Host "=== WiX directories on runner (before) ==="
+          Get-ChildItem 'C:\Program Files (x86)' -Filter 'WiX*' -Directory | Select-Object FullName | Format-Table -AutoSize | Out-String | Write-Host
+
+          # Remove pre-installed WiX v3.14 so v3.11.2 installs cleanly to its own path.
+          # The choco package's underlying .exe installer no-ops if any v3.x is present,
+          # which is why our previous attempt "succeeded" without actually downgrading.
+          choco uninstall wixtoolset -y --no-progress --skip-autouninstaller-failure-check || Write-Host "(no existing choco wixtoolset to uninstall)"
+          Get-ChildItem 'C:\Program Files (x86)' -Filter 'WiX Toolset v3.*' -Directory -ErrorAction SilentlyContinue | ForEach-Object {
+              Write-Host "Removing $($_.FullName)"
+              Remove-Item $_.FullName -Recurse -Force -ErrorAction SilentlyContinue
+          }
+
+          choco install wixtoolset --version=3.11.2 --force -y --no-progress
+
+          Write-Host ""
+          Write-Host "=== WiX directories on runner (after) ==="
+          Get-ChildItem 'C:\Program Files (x86)' -Filter 'WiX*' -Directory | Select-Object FullName | Format-Table -AutoSize | Out-String | Write-Host
+
+          $wixRoot = Get-ChildItem 'C:\Program Files (x86)' -Filter 'WiX Toolset v3.11*' -Directory -ErrorAction SilentlyContinue | Select-Object -First 1 -ExpandProperty FullName
+          if (-not $wixRoot) { throw "WiX 3.11 install did not produce expected path under C:\Program Files (x86)" }
+          $wixBin = Join-Path $wixRoot 'bin'
+          if (-not (Test-Path $wixBin)) { throw "WiX 3.11 install missing bin\: $wixBin" }
+
+          "WIX=$wixRoot\"   | Out-File -FilePath $env:GITHUB_ENV  -Append
+          "$wixBin"         | Out-File -FilePath $env:GITHUB_PATH -Append
+          Write-Host "Pinned WiX root: $wixRoot"
+          & "$wixBin\candle.exe" -? | Select-Object -First 1 | Write-Host
 
       - name: Build installer
         id: build

--- a/.github/workflows/build-installer.yml
+++ b/.github/workflows/build-installer.yml
@@ -1,16 +1,14 @@
 # Build Installer — GitHub Actions replacement for BHoMBot's 00:45 UTC alpha build.
 #
-# Initial iteration: workflow_dispatch only, so we can trigger manually and iterate.
-# Once a green build is produced, uncomment the schedule trigger to enable nightly
-# alpha cadence matching BHoMBot.
+# Triggers:
+#   schedule           — nightly 00:45 UTC, fires on the default branch only.
+#                        Note: schedule events do NOT pass workflow inputs, so
+#                        the build defaults to release_type=alpha (handled in
+#                        Build-Installer.ps1 via 'inputs.release_type || alpha').
+#   workflow_dispatch  — manual run for iteration + ad-hoc test builds.
 #
-# Triggers (Phase 1):
-#   workflow_dispatch  — manual run for iteration + ad-hoc beta-test builds
-#   schedule (commented out for now) — nightly 00:45 UTC for alpha cadence
-#
-# Triggers to be added later:
-#   push: tags v*     — Phase 1.5, tagged release builds
-#   schedule          — uncomment once dispatch is reliable
+# Trigger to be added later:
+#   push: tags v*      — Phase 2+, tagged release builds for beta-test / stable
 
 name: Build Installer
 
@@ -30,9 +28,8 @@ on:
         required: false
         default: ''
 
-  # Uncomment once workflow_dispatch produces a clean .msi reliably:
-  # schedule:
-  #   - cron: '45 0 * * *'   # 00:45 UTC nightly, matching BHoMBot
+  schedule:
+    - cron: '45 0 * * *'   # 00:45 UTC nightly, matching BHoMBot
 
 permissions:
   contents: read
@@ -305,3 +302,106 @@ jobs:
             uninstall.utf8.log
           if-no-files-found: warn
           retention-days: 14
+
+  # Publish the validated .msi to a rolling 'nightly-alpha' Release tag.
+  # Same tag is updated on every successful nightly + dispatch build, so users
+  # have one stable URL for the latest alpha:
+  #   https://github.com/<repo>/releases/tag/nightly-alpha
+  #
+  # Gated behind install-test passing on all matrix legs. Only publishes alphas
+  # (beta and other release types are skipped here — they'd get their own tag
+  # in a future iteration). prerelease: true keeps the 'Latest release' badge
+  # reserved for semver-tagged stable builds.
+  publish-alpha:
+    name: Publish nightly-alpha release
+    needs: [build, install-test]
+    if: |
+      success() &&
+      (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') &&
+      (inputs.release_type == 'alpha' || inputs.release_type == null || inputs.release_type == '')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download .msi artefact
+        uses: actions/download-artifact@v4
+        with:
+          name: installer-${{ inputs.release_type || 'alpha' }}-${{ github.run_id }}
+          path: msi
+
+      - name: Publish / update rolling release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: nightly-alpha
+          name: BHoM Alpha (Nightly)
+          body: |
+            **Latest BHoM alpha build.**
+
+            - Build: [#${{ github.run_id }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
+            - Commit: `${{ github.sha }}`
+            - Triggered by: `${{ github.event_name }}`
+            - Built: `${{ github.event.repository.updated_at }}`
+
+            Install: download the `.msi`, double-click. Uninstall via Windows
+            "Apps & Features".
+
+            This tag is re-issued on every successful nightly build and on
+            on-demand `workflow_dispatch` runs — bookmark this page for the
+            latest alpha.
+          files: msi/*.msi
+          make_latest: false
+          prerelease: true
+
+  # Open a GitHub Issue when a scheduled nightly fails so the breakage doesn't
+  # rot silently overnight. Only fires on schedule events (not on dispatch —
+  # the human triggering a dispatch already knows what they're doing).
+  notify-on-failure:
+    name: Open issue on failed nightly
+    needs: [build, install-test]
+    if: failure() && github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Open or update tracking issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BUILD_RESULT: ${{ needs.build.result }}
+          TEST_RESULT:  ${{ needs.install-test.result }}
+        run: |
+          set -eu
+          today=$(date -u +%Y-%m-%d)
+          title="[CI] Nightly alpha build failed ($today)"
+          run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+
+          body=$(cat <<EOF
+          The scheduled nightly alpha build failed.
+
+          - **Run:** ${run_url}
+          - **Commit:** \`${GITHUB_SHA}\`
+          - **build job:** \`${BUILD_RESULT}\`
+          - **install-test matrix:** \`${TEST_RESULT}\`
+
+          See the run log for details. This issue auto-opens when a scheduled
+          run fails; close it once the underlying issue is resolved.
+          EOF
+          )
+
+          # Avoid spamming: if an open issue already exists with this exact
+          # title (i.e. another failure already happened today), comment on it
+          # instead of opening a duplicate.
+          existing=$(gh issue list \
+              --repo "$GITHUB_REPOSITORY" \
+              --search "in:title \"$title\"" \
+              --state open \
+              --json number --jq '.[0].number // empty')
+
+          if [ -n "$existing" ]; then
+              gh issue comment "$existing" --repo "$GITHUB_REPOSITORY" --body "$body"
+              echo "Commented on existing issue #$existing"
+          else
+              gh issue create \
+                  --repo "$GITHUB_REPOSITORY" \
+                  --title "$title" \
+                  --body "$body"
+          fi

--- a/.github/workflows/build-installer.yml
+++ b/.github/workflows/build-installer.yml
@@ -57,6 +57,33 @@ jobs:
       # BuroHappold_Installer (which bundles private BHE repos), add the
       # mint-dep-token step here.
 
+      - name: Compute cache key date
+        id: cache-date
+        run: |
+          "today=$(Get-Date -Format yyyy-MM-dd)" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+
+      - name: Cache BHoM dep clones + ProgramData
+        # Cache the cloned dep repos alongside the installer checkout and the
+        # ProgramData\BHoM staging area where every dep's PostBuildEvent xcopies
+        # its DLLs. With a same-day cache hit:
+        #   - Clone-Repo skips re-cloning (already idempotent on existing .git)
+        #   - MSBuild incremental sees no source changes and short-circuits
+        #   - PostBuildEvents don't fire (no inputs newer than outputs)
+        #   - ProgramData is already populated from the cache
+        # Net: 12-min cold build collapses to ~3-4 min on warm reruns.
+        #
+        # The 'today' date in the key forces a fresh full build at most every
+        # 24h, matching BHoMBot's nightly cadence. No restore-keys / fallback,
+        # so we never use a >1-day-old cache (would risk shipping stale deps).
+        id: deps-cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            D:/a/BHoM_Installer
+            !D:/a/BHoM_Installer/BHoM_Installer
+            C:/ProgramData/BHoM
+          key: bhom-deps-${{ inputs.release_type }}-${{ hashFiles('IncludedRepos/*.txt') }}-${{ steps.cache-date.outputs.today }}
+
       - name: Pin WiX Toolset v3.11.2
         # GHA windows-2025-vs2026 ships WiX v3.14. The v3.14 SfxCA.dll stub
         # (bundled by MakeSfxCA into InstallerCA.CA.dll) appears to be the

--- a/.github/workflows/build-installer.yml
+++ b/.github/workflows/build-installer.yml
@@ -449,10 +449,7 @@ jobs:
           fi
 
           cat >release-body.md <<EOF
-          ## BHoM Alpha Installer
-
-          This is a pre-release build of the BHoM installer produced by the
-          alpha CI pipeline. See the build provenance below before installing.
+          Pre-release build of the BHoM installer produced by the alpha CI pipeline. See the build provenance below before installing.
 
           ### Build provenance
 
@@ -462,12 +459,6 @@ jobs:
           | Commit | \`${GITHUB_SHA}\` |
           | Triggered by | \`${GITHUB_EVENT_NAME}\` |
           | Test status | $test_status |
-
-          ### Installation
-
-          Download the \`.msi\` attached to this release and run it to install.
-          To uninstall, use **Settings > Apps > Installed apps** (or the legacy
-          "Apps & Features" panel) and remove "Buildings and Habitats object Model".
 
           ### Changes
 

--- a/.github/workflows/build-installer.yml
+++ b/.github/workflows/build-installer.yml
@@ -57,6 +57,45 @@ jobs:
       # BuroHappold_Installer (which bundles private BHE repos), add the
       # mint-dep-token step here.
 
+      - name: Provide .NET Framework 4.0 reference assemblies
+        # InstallerCA.csproj targets .NET Framework v4.0 (matches BHoMBot's build
+        # exactly — we deliberately do not modify the installer source). The
+        # windows-2025-vs2026 image ships no v4.0 targeting pack, so MSBuild errors
+        # with MSB3644 unless we point it at a NuGet-restored copy of the v4.0
+        # reference assemblies.
+        #
+        # We expose them via a workspace-level Directory.Build.props (one dir above
+        # the installer checkout) that conditionally sets FrameworkPathOverride
+        # only when a project targets v4.0 — keeps the rest of the dep builds
+        # (which target newer TFMs) unaffected and leaves the installer repo
+        # untouched.
+        run: |
+          $pkgDir = 'C:\refasms'
+          New-Item -ItemType Directory -Force -Path $pkgDir | Out-Null
+          nuget install Microsoft.NETFramework.ReferenceAssemblies.net40 `
+            -OutputDirectory $pkgDir -Version 1.0.3 -ExcludeVersion -Verbosity quiet `
+            -Source https://api.nuget.org/v3/index.json
+          $refPath = "$pkgDir\Microsoft.NETFramework.ReferenceAssemblies.net40\build\.NETFramework\v4.0"
+          if (-not (Test-Path "$refPath\mscorlib.dll")) {
+              throw "v4.0 ref assemblies missing at $refPath"
+          }
+
+          # actions/checkout puts the installer repo at D:\a\BHoM_Installer\BHoM_Installer.
+          # Workspace parent is D:\a\BHoM_Installer (where deps get cloned alongside).
+          # Directory.Build.props at the parent is walked-up by MSBuild for every
+          # project under the workspace.
+          $propsPath = 'D:\a\BHoM_Installer\Directory.Build.props'
+          $propsContent = @"
+<Project>
+  <PropertyGroup Condition=`" '`$(TargetFrameworkIdentifier)' == '.NETFramework' AND '`$(TargetFrameworkVersion)' == 'v4.0' `">
+    <FrameworkPathOverride>$refPath</FrameworkPathOverride>
+  </PropertyGroup>
+</Project>
+"@
+          Set-Content -Path $propsPath -Value $propsContent -Encoding UTF8
+          Write-Host "Wrote $propsPath"
+          Write-Host "FrameworkPathOverride (v4.0 only) = $refPath"
+
       - name: Compute cache key date
         id: cache-date
         run: |

--- a/.github/workflows/build-installer.yml
+++ b/.github/workflows/build-installer.yml
@@ -338,23 +338,23 @@ jobs:
           if-no-files-found: warn
           retention-days: 14
 
-  # Publish the .msi as a preserved per-build Release. Tag scheme:
-  #   schedule         → alpha-{YYYYMMDD}                    (one per day)
-  #   workflow_dispatch → manual-alpha-{YYYYMMDD-HHMMSS}    (one per dispatch)
-  # No rolling tag: each release stays as history. No "skip if unchanged"
-  # gate: the build itself runs every cycle as a CI heartbeat.
+  # Publish the .msi as a preserved per-build Release. Single tag scheme for
+  # both triggers:
+  #   alpha-{YYYYMMDD-HHMMSS}
+  # The 'Triggered by:' line in the release body distinguishes scheduled
+  # nightlies from manual dispatches — no need to encode that in the tag.
+  # Each release is preserved (no rolling tag, no overwrite). History
+  # accumulates indefinitely.
   #
-  # Publishes even if install-test failed — the .msi is still useful for
-  # local diagnostic testing. The body surfaces the test result so users
-  # know whether to trust the build for production use.
+  # Gated on the entire pipeline succeeding (build + install-test). Failed
+  # builds don't appear on the Releases page; the team can still grab the
+  # .msi from the workflow run's "Upload installer artefact" Actions artifact
+  # to debug locally.
   publish-alpha:
     name: Publish alpha release
     needs: [build, install-test]
-    # always() overrides the implicit "all needs succeeded" gate so that
-    # install-test failure doesn't block publishing.
     if: |
-      always() &&
-      needs.build.result == 'success' &&
+      success() &&
       (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') &&
       (inputs.release_type == 'alpha' || inputs.release_type == null || inputs.release_type == '')
     runs-on: ubuntu-latest
@@ -380,13 +380,8 @@ jobs:
         shell: bash
         run: |
           set -eu
-          if [ "$GITHUB_EVENT_NAME" = "schedule" ]; then
-              tag="alpha-$(date -u +%Y%m%d)"
-              name="BHoM Alpha — $(date -u +%Y-%m-%d)"
-          else
-              tag="manual-alpha-$(date -u +%Y%m%d-%H%M%S)"
-              name="BHoM Alpha — manual $(date -u +'%Y-%m-%d %H:%M:%S') UTC"
-          fi
+          tag="alpha-$(date -u +%Y%m%d-%H%M%S)"
+          name="BHoM Alpha — $(date -u +'%Y-%m-%d %H:%M:%S') UTC"
           echo "tag=$tag"   >> "$GITHUB_OUTPUT"
           echo "name=$name" >> "$GITHUB_OUTPUT"
           echo "::notice::Release tag = $tag"
@@ -399,16 +394,13 @@ jobs:
         run: |
           set -eu
           mkdir -p prev
-          # List releases, pick the most recent prior alpha-related release.
-          # The 'nightly-alpha$' clause is a one-time bootstrap: the sandbox
-          # already has a release under that tag from an earlier iteration of
-          # this workflow. Once the first new alpha-* release is published we
-          # can safely drop it from the pattern.
+          # Most recent prior alpha release. Tag scheme is alpha-{timestamp},
+          # so a single anchored prefix is sufficient.
           prev_tag=$(gh release list \
               --repo "$GITHUB_REPOSITORY" \
               --limit 50 \
               --json tagName,createdAt \
-              --jq "[.[] | select(.tagName | test(\"^(alpha-|manual-alpha-|nightly-alpha\$)\")) | select(.tagName != \"$CURRENT_TAG\")] | sort_by(.createdAt) | reverse | .[0].tagName // \"\"")
+              --jq "[.[] | select(.tagName | test(\"^alpha-\")) | select(.tagName != \"$CURRENT_TAG\")] | sort_by(.createdAt) | reverse | .[0].tagName // \"\"")
           if [ -n "$prev_tag" ] && gh release download "$prev_tag" \
               --repo "$GITHUB_REPOSITORY" \
               --pattern dep-manifest.json \

--- a/.github/workflows/build-installer.yml
+++ b/.github/workflows/build-installer.yml
@@ -1,14 +1,14 @@
-# Build Installer — GitHub Actions replacement for BHoMBot's 00:45 UTC alpha build.
+# Build Installer. GitHub Actions replacement for BHoMBot's 00:45 UTC alpha build.
 #
 # Triggers:
-#   schedule           — nightly 00:45 UTC, fires on the default branch only.
-#                        Note: schedule events do NOT pass workflow inputs, so
-#                        the build defaults to release_type=alpha (handled in
-#                        Build-Installer.ps1 via 'inputs.release_type || alpha').
-#   workflow_dispatch  — manual run for iteration + ad-hoc test builds.
+#   schedule           Nightly 00:45 UTC, fires on the default branch only.
+#                      Schedule events do not pass workflow inputs, so the
+#                      build defaults to release_type=alpha (handled in
+#                      Build-Installer.ps1 via 'inputs.release_type || alpha').
+#   workflow_dispatch  Manual run for iteration and ad-hoc test builds.
 #
 # Trigger to be added later:
-#   push: tags v*      — Phase 2+, tagged release builds for beta-test / stable
+#   push: tags v*      Phase 2+, tagged release builds for beta-test and stable.
 
 name: Build Installer
 
@@ -55,24 +55,27 @@ jobs:
       # mint-dep-token step here.
 
       - name: Provide .NET Framework 4.0 reference assemblies
-        # InstallerCA.csproj targets .NET Framework v4.0 (matches BHoMBot's build
-        # exactly — we deliberately do not modify the installer source). The
-        # windows-2025-vs2026 image ships no v4.0 targeting pack, so MSBuild errors
-        # with MSB3644 unless v4.0 reference assemblies are present somewhere it
-        # knows to look.
+        # InstallerCA.csproj targets .NET Framework v4.0, matching BHoMBot's
+        # build exactly so that the installer source tree stays untouched. The
+        # windows-2025-vs2026 image ships no v4.0 targeting pack, so MSBuild
+        # errors with MSB3644 unless v4.0 reference assemblies are available
+        # in a location it knows to look.
         #
-        # We restore them via the standard NuGet package and copy into the
+        # Restore them via the standard NuGet package and copy into the
         # canonical Visual Studio targeting-pack location:
         #   C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.0\
         # MSBuild's GetReferenceAssemblyPaths task then resolves v4.0 there
-        # naturally, exactly as if the .NET Framework 4.0 SDK were installed.
-        # No Directory.Build.props / FrameworkPathOverride is needed — that
-        # approach broke silently because Directory.Build.props is imported
-        # before the csproj's <PropertyGroup> sets TargetFrameworkVersion, so a
-        # conditional 'TargetFrameworkVersion == v4.0' never matched.
+        # naturally, as if the .NET Framework 4.0 SDK were installed.
         #
-        # v4.8 and later TFMs are unaffected: their targeting packs live at
-        # separate per-version paths, untouched by this step.
+        # A Directory.Build.props / FrameworkPathOverride approach was tried
+        # first and abandoned: that file is imported into project evaluation
+        # before the csproj sets TargetFrameworkVersion, so a conditional
+        # 'TargetFrameworkVersion == v4.0' never matches and the override is
+        # never applied. The cached-binaries from earlier sessions masked this
+        # until the cache was removed.
+        #
+        # v4.8 and later TFMs are unaffected. Their targeting packs live at
+        # separate per-version paths and are not touched by this step.
         run: |
           $pkgDir = 'C:\refasms'
           New-Item -ItemType Directory -Force -Path $pkgDir | Out-Null
@@ -188,7 +191,7 @@ jobs:
           $mb = [math]::Round($msi.Length / 1MB, 2)
           Write-Host "::notice::.msi size: $mb MB ($($msi.Name))"
           if ($mb -lt 30 -or $mb -gt 100) {
-              throw ".msi size $mb MB is outside the 30-100 MB sanity range — possible packaging regression"
+              throw ".msi size $mb MB is outside the 30-100 MB sanity range, indicating a possible packaging regression"
           }
 
       - name: Upload installer artefact
@@ -242,14 +245,15 @@ jobs:
           # MSI verbose log is UTF-16LE by default. Convert for searchability.
           Get-Content install.log -Encoding Unicode | Set-Content install.utf8.log -Encoding UTF8
 
-          # Hard fatal markers — any of these means a fatal action / engine
-          # failure that rolled back the transaction. We deliberately do NOT
-          # flag bare 'returned actual error code 1603' lines: WiX marks some
-          # custom actions Continue="yes" (WixRemoveFoldersEx, Action_RegisterAddIn,
-          # Action_UnRegisterAddInOld) and the log records the 1603 followed by
-          # "but will be translated to success due to continue marking" — those
-          # are by-design non-fatal and the real-fatal case still triggers
-          # Return value 3 + MainEngineThread 1603 which the patterns below catch.
+          # Hard fatal markers. Any of these indicates a fatal action or
+          # engine failure that rolled back the transaction. Bare
+          # 'returned actual error code 1603' lines are deliberately not
+          # flagged: WiX marks some custom actions with Continue="yes"
+          # (WixRemoveFoldersEx, Action_RegisterAddIn, Action_UnRegisterAddInOld).
+          # The log records the 1603 followed by "but will be translated to
+          # success due to continue marking", which is by-design non-fatal.
+          # The genuinely-fatal case still produces 'Return value 3' and
+          # 'MainEngineThread is returning 1603', which the patterns below catch.
           $patterns = @(
               'Return value 3',
               'MainEngineThread is returning 1603',
@@ -261,9 +265,9 @@ jobs:
               throw "Fatal markers found in install log"
           }
 
-          # Positive success check — the engine MUST have logged a clean exit.
+          # Positive success check. The engine must have logged a clean exit.
           if (-not (Select-String -Path install.utf8.log -Pattern 'Installation success or error status: 0' -Quiet)) {
-              throw "Install log missing 'Installation success or error status: 0' — install did not complete cleanly"
+              throw "Install log missing 'Installation success or error status: 0'. Install did not complete cleanly."
           }
 
           # File-existence assertions on the things WiX components claim to ship
@@ -286,14 +290,15 @@ jobs:
           $onDiskDlls      = (Get-ChildItem 'C:\ProgramData\BHoM\Assemblies' -Filter '*.dll' -ErrorAction SilentlyContinue).Count
           Write-Host "::notice::Assemblies on disk: $onDiskDlls    IncludedDLLs.txt manifest: $manifestEntries"
           if ($onDiskDlls -lt $manifestEntries) {
-              throw "Only $onDiskDlls DLLs installed but manifest declares $manifestEntries — components missing"
+              throw "Only $onDiskDlls DLLs installed but manifest declares $manifestEntries. Components are missing."
           }
 
-          # BHoM.dll loadability smoke: assembly must be a valid .NET assembly with
-          # a resolvable identity. We deliberately don't call GetTypes() — that
-          # requires every referenced dep to be resolvable in the load context,
-          # which is fragile for a per-file Assembly.LoadFrom. AssemblyName resolution
-          # is enough to catch "build emitted a corrupted DLL" without false fails.
+          # BHoM.dll loadability smoke: assembly must be a valid .NET assembly
+          # with a resolvable identity. GetTypes() is deliberately not called
+          # because it requires every referenced dep to be resolvable in the
+          # load context, which is fragile for a per-file Assembly.LoadFrom.
+          # AssemblyName resolution is enough to catch a corrupted-DLL build
+          # without introducing false failures.
           try {
               $asm  = [System.Reflection.Assembly]::LoadFrom('C:\ProgramData\BHoM\Assemblies\BHoM.dll')
               $name = $asm.GetName()
@@ -342,14 +347,14 @@ jobs:
   # both triggers:
   #   alpha-{YYYYMMDD-HHMMSS}
   # The 'Triggered by:' line in the release body distinguishes scheduled
-  # nightlies from manual dispatches — no need to encode that in the tag.
-  # Each release is preserved (no rolling tag, no overwrite). History
-  # accumulates indefinitely.
+  # nightlies from manual dispatches; there is no need to encode that in the
+  # tag itself. Each release is preserved (no rolling tag, no overwrite) and
+  # history accumulates indefinitely.
   #
   # Gated on the entire pipeline succeeding (build + install-test). Failed
-  # builds don't appear on the Releases page; the team can still grab the
-  # .msi from the workflow run's "Upload installer artefact" Actions artifact
-  # to debug locally.
+  # builds do not appear on the Releases page. The .msi remains accessible
+  # from the workflow run's "Upload installer artefact" Actions artifact for
+  # local debugging when smoke tests fail.
   publish-alpha:
     name: Publish alpha release
     needs: [build, install-test]
@@ -375,13 +380,13 @@ jobs:
           name: installer-${{ inputs.release_type || 'alpha' }}-${{ github.run_id }}
           path: artefact
 
-      - name: Compute release tag + name
+      - name: Compute release tag and name
         id: tag
         shell: bash
         run: |
           set -eu
           tag="alpha-$(date -u +%Y%m%d-%H%M%S)"
-          name="BHoM Alpha — $(date -u +'%Y-%m-%d %H:%M:%S') UTC"
+          name="BHoM Alpha Installer ($(date -u +'%Y-%m-%d %H:%M:%S') UTC)"
           echo "tag=$tag"   >> "$GITHUB_OUTPUT"
           echo "name=$name" >> "$GITHUB_OUTPUT"
           echo "::notice::Release tag = $tag"
@@ -409,7 +414,7 @@ jobs:
               echo "path=prev/dep-manifest.json" >> "$GITHUB_OUTPUT"
               echo "prev_tag=$prev_tag"          >> "$GITHUB_OUTPUT"
           else
-              echo "::notice::No prior alpha release with a manifest — this will be an initial-baseline publish"
+              echo "::notice::No prior alpha release with a manifest. This will be an initial-baseline publish."
               echo "path="     >> "$GITHUB_OUTPUT"
               echo "prev_tag=" >> "$GITHUB_OUTPUT"
           fi
@@ -432,31 +437,41 @@ jobs:
           run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
 
           if [ "$INSTALL_TEST_RESULT" = "success" ]; then
-              test_status="✅ install + uninstall smoke test passed on both windows-2022 and windows-2025"
+              test_status="Passed install and uninstall smoke tests on windows-2022 and windows-2025."
           else
-              test_status="⚠️ install + uninstall smoke test result: \`$INSTALL_TEST_RESULT\` — see [run logs]($run_url). **Download for diagnostic / local testing only — do not promote to users.**"
+              test_status="Smoke test result: \`$INSTALL_TEST_RESULT\`. See [run logs]($run_url) for details. This build is provided for diagnostic and local testing only and should not be promoted to users."
           fi
 
           if [ -n "$PREV_TAG" ]; then
-              diff_note="Diffed against [\`$PREV_TAG\`](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/releases/tag/${PREV_TAG})."
+              diff_note="Changes are computed against [\`$PREV_TAG\`](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/releases/tag/${PREV_TAG})."
           else
-              diff_note="(No prior alpha release found — this is an initial baseline.)"
+              diff_note="No prior alpha release was found, so this build is published as an initial baseline."
           fi
 
           cat >release-body.md <<EOF
-          **BHoM alpha build.**
+          ## BHoM Alpha Installer
 
-          - Build: [#${GITHUB_RUN_ID}]($run_url)
-          - Commit: \`${GITHUB_SHA}\`
-          - Triggered by: \`${GITHUB_EVENT_NAME}\`
-          - **Test status:** $test_status
+          This is a pre-release build of the BHoM installer produced by the
+          alpha CI pipeline. See the build provenance below before installing.
 
-          Install: download the \`.msi\`, double-click. Uninstall via Windows
-          "Apps & Features".
+          ### Build provenance
+
+          | Field | Value |
+          |---|---|
+          | Build | [#${GITHUB_RUN_ID}]($run_url) |
+          | Commit | \`${GITHUB_SHA}\` |
+          | Triggered by | \`${GITHUB_EVENT_NAME}\` |
+          | Test status | $test_status |
+
+          ### Installation
+
+          Download the \`.msi\` attached to this release and run it to install.
+          To uninstall, use **Settings > Apps > Installed apps** (or the legacy
+          "Apps & Features" panel) and remove "Buildings and Habitats object Model".
+
+          ### Changes
 
           $diff_note
-
-          ---
 
           EOF
           cat release-notes-section.md >> release-body.md
@@ -476,9 +491,10 @@ jobs:
           make_latest: false
           prerelease: true
 
-  # Open a GitHub Issue when a scheduled nightly fails so the breakage doesn't
-  # rot silently overnight. Only fires on schedule events (not on dispatch —
-  # the human triggering a dispatch already knows what they're doing).
+  # Open a GitHub Issue when a scheduled nightly fails so the breakage does
+  # not rot silently overnight. Only fires on schedule events (not on
+  # dispatch, on the grounds that the human triggering a dispatch is already
+  # aware of the run).
   notify-on-failure:
     name: Open issue on failed nightly
     needs: [build, install-test]
@@ -504,13 +520,13 @@ jobs:
           # below is an extra signal on top of this.
           echo "::error title=Nightly alpha build failed::See $run_url"
 
-          # Skip tracking-issue creation if the repo has Issues disabled
-          # (this surfaced on the sandbox repo when notify-on-failure was
-          # first smoke-tested — gh issue create errors with 'repository has
-          # disabled issues'). The annotation above remains the signal.
+          # Skip tracking-issue creation if the repo has Issues disabled.
+          # This case surfaced on the sandbox repo when notify-on-failure was
+          # first smoke-tested: gh issue create errors with 'repository has
+          # disabled issues'. The annotation above remains the failure signal.
           has_issues=$(gh api "repos/$GITHUB_REPOSITORY" --jq '.has_issues // false')
           if [ "$has_issues" != "true" ]; then
-              echo "::notice::Issues disabled on $GITHUB_REPOSITORY — skipping tracking-issue creation. Workflow annotation above remains the failure marker."
+              echo "::notice::Issues are disabled on $GITHUB_REPOSITORY. Skipping tracking-issue creation; the workflow annotation above remains the failure marker."
               exit 0
           fi
 

--- a/.github/workflows/build-installer.yml
+++ b/.github/workflows/build-installer.yml
@@ -58,40 +58,37 @@ jobs:
         # InstallerCA.csproj targets .NET Framework v4.0 (matches BHoMBot's build
         # exactly — we deliberately do not modify the installer source). The
         # windows-2025-vs2026 image ships no v4.0 targeting pack, so MSBuild errors
-        # with MSB3644 unless we point it at a NuGet-restored copy of the v4.0
-        # reference assemblies.
+        # with MSB3644 unless v4.0 reference assemblies are present somewhere it
+        # knows to look.
         #
-        # We expose them via a workspace-level Directory.Build.props (one dir above
-        # the installer checkout) that conditionally sets FrameworkPathOverride
-        # only when a project targets v4.0 — keeps the rest of the dep builds
-        # (which target newer TFMs) unaffected and leaves the installer repo
-        # untouched.
+        # We restore them via the standard NuGet package and copy into the
+        # canonical Visual Studio targeting-pack location:
+        #   C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.0\
+        # MSBuild's GetReferenceAssemblyPaths task then resolves v4.0 there
+        # naturally, exactly as if the .NET Framework 4.0 SDK were installed.
+        # No Directory.Build.props / FrameworkPathOverride is needed — that
+        # approach broke silently because Directory.Build.props is imported
+        # before the csproj's <PropertyGroup> sets TargetFrameworkVersion, so a
+        # conditional 'TargetFrameworkVersion == v4.0' never matched.
+        #
+        # v4.8 and later TFMs are unaffected: their targeting packs live at
+        # separate per-version paths, untouched by this step.
         run: |
           $pkgDir = 'C:\refasms'
           New-Item -ItemType Directory -Force -Path $pkgDir | Out-Null
           nuget install Microsoft.NETFramework.ReferenceAssemblies.net40 `
             -OutputDirectory $pkgDir -Version 1.0.3 -ExcludeVersion -Verbosity quiet `
             -Source https://api.nuget.org/v3/index.json
-          $refPath = "$pkgDir\Microsoft.NETFramework.ReferenceAssemblies.net40\build\.NETFramework\v4.0"
-          if (-not (Test-Path "$refPath\mscorlib.dll")) {
-              throw "v4.0 ref assemblies missing at $refPath"
+          $src = "$pkgDir\Microsoft.NETFramework.ReferenceAssemblies.net40\build\.NETFramework\v4.0"
+          if (-not (Test-Path "$src\mscorlib.dll")) {
+              throw "v4.0 ref assemblies missing at $src after nuget install"
           }
 
-          # actions/checkout puts the installer repo at D:\a\BHoM_Installer\BHoM_Installer.
-          # Workspace parent is D:\a\BHoM_Installer (where deps get cloned alongside).
-          # Directory.Build.props at the parent is walked-up by MSBuild for every
-          # project under the workspace.
-          $propsPath = 'D:\a\BHoM_Installer\Directory.Build.props'
-          $lines = @(
-              '<Project>',
-              '  <PropertyGroup Condition=" ''$(TargetFrameworkIdentifier)'' == ''.NETFramework'' AND ''$(TargetFrameworkVersion)'' == ''v4.0'' ">',
-              "    <FrameworkPathOverride>$refPath</FrameworkPathOverride>",
-              '  </PropertyGroup>',
-              '</Project>'
-          )
-          Set-Content -Path $propsPath -Value $lines -Encoding UTF8
-          Write-Host "Wrote $propsPath"
-          Write-Host "FrameworkPathOverride (v4.0 only) = $refPath"
+          $dst = 'C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.0'
+          New-Item -ItemType Directory -Force -Path $dst | Out-Null
+          Copy-Item -Path "$src\*" -Destination $dst -Recurse -Force
+          Write-Host "Installed v4.0 reference assemblies to: $dst"
+          Get-ChildItem $dst -Filter '*.dll' | Measure-Object | ForEach-Object { Write-Host "  $($_.Count) DLLs present" }
 
       - name: Pin WiX Toolset v3.11.2
         # GHA windows-2025-vs2026 ships WiX v3.14. The v3.14 SfxCA.dll stub

--- a/.github/workflows/build-installer.yml
+++ b/.github/workflows/build-installer.yml
@@ -1,0 +1,94 @@
+# Build Installer — GitHub Actions replacement for BHoMBot's 00:45 UTC alpha build.
+#
+# Initial iteration: workflow_dispatch only, so we can trigger manually and iterate.
+# Once a green build is produced, uncomment the schedule trigger to enable nightly
+# alpha cadence matching BHoMBot.
+#
+# Triggers (Phase 1):
+#   workflow_dispatch  — manual run for iteration + ad-hoc beta-test builds
+#   schedule (commented out for now) — nightly 00:45 UTC for alpha cadence
+#
+# Triggers to be added later:
+#   push: tags v*     — Phase 1.5, tagged release builds
+#   schedule          — uncomment once dispatch is reliable
+
+name: Build Installer
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_type:
+        description: 'Release type'
+        type: choice
+        options:
+          - alpha
+          - beta
+        default: alpha
+      patch_version:
+        description: 'Patch version (yyMMdd). Blank = today.'
+        type: string
+        required: false
+        default: ''
+
+  # Uncomment once workflow_dispatch produces a clean .msi reliably:
+  # schedule:
+  #   - cron: '45 0 * * *'   # 00:45 UTC nightly, matching BHoMBot
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build ${{ inputs.release_type || 'alpha' }} installer
+    runs-on: windows-2025-vs2026
+    timeout-minutes: 180   # generous; tighten once we know real duration
+    defaults:
+      run:
+        shell: pwsh
+
+    steps:
+      - name: Checkout installer repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Mint cross-org dependency token
+        id: dep-token
+        uses: BuroHappoldEngineeringAdmin/CI_Toolkit/.github/actions/mint-dep-token@main
+        with:
+          app_id:         ${{ secrets.BHOM_APP_ID }}
+          private_key:    ${{ secrets.BHOM_APP_PRIVATE_KEY }}
+          fallback_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Configure git to use the minted token
+        run: |
+          # Inject the token at git-config level so subsequent clones authenticate.
+          # Avoids embedding the token in URLs (would land in process listings + repo clones).
+          git config --global url."https://x-access-token:${{ steps.dep-token.outputs.token }}@github.com/".insteadOf "https://github.com/"
+
+      - name: Build installer
+        id: build
+        run: |
+          $releaseType = '${{ inputs.release_type }}'
+          if (-not $releaseType) { $releaseType = 'alpha' }
+
+          $patchVersion = '${{ inputs.patch_version }}'
+
+          $args = @('-ReleaseType', $releaseType)
+          if ($patchVersion) { $args += @('-PatchVersion', $patchVersion) }
+
+          & "$env:GITHUB_WORKSPACE\scripts\Build-Installer.ps1" @args
+
+      - name: Upload installer artefact
+        if: success()
+        uses: actions/upload-artifact@v4
+        with:
+          name: installer-${{ inputs.release_type || 'alpha' }}-${{ github.run_id }}
+          path: ${{ github.workspace }}/Build/*.msi
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Cleanup token config
+        if: always()
+        run: |
+          git config --global --unset url."https://x-access-token:${{ steps.dep-token.outputs.token }}@github.com/".insteadOf 2>$null

--- a/.github/workflows/build-installer.yml
+++ b/.github/workflows/build-installer.yml
@@ -498,6 +498,22 @@ jobs:
           title="[CI] Nightly alpha build failed ($today)"
           run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
 
+          # ALWAYS emit a workflow-page-visible annotation. This is the lower
+          # bound: a failure indicator that's visible regardless of whether
+          # the consumer repo has Issues enabled. The tracking-issue creation
+          # below is an extra signal on top of this.
+          echo "::error title=Nightly alpha build failed::See $run_url"
+
+          # Skip tracking-issue creation if the repo has Issues disabled
+          # (this surfaced on the sandbox repo when notify-on-failure was
+          # first smoke-tested — gh issue create errors with 'repository has
+          # disabled issues'). The annotation above remains the signal.
+          has_issues=$(gh api "repos/$GITHUB_REPOSITORY" --jq '.has_issues // false')
+          if [ "$has_issues" != "true" ]; then
+              echo "::notice::Issues disabled on $GITHUB_REPOSITORY — skipping tracking-issue creation. Workflow annotation above remains the failure marker."
+              exit 0
+          fi
+
           body=$(cat <<EOF
           The scheduled nightly alpha build failed.
 

--- a/.gitignore
+++ b/.gitignore
@@ -266,3 +266,7 @@ Build/
 InstallerCore/Upgrades
 Extensions/
 InstallerCore/Resources/
+
+# Local working notes — not part of the project history
+docs/superpowers/
+docs/session-notes/

--- a/InstallerCA/InstallerCA.csproj
+++ b/InstallerCA/InstallerCA.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>InstallerCA</RootNamespace>
     <AssemblyName>InstallerCA</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <WixCATargetsPath Condition=" '$(WixCATargetsPath)' == '' ">$(MSBuildExtensionsPath)\Microsoft\WiX\v3.x\Wix.CA.targets</WixCATargetsPath>
   </PropertyGroup>

--- a/InstallerCA/InstallerCA.csproj
+++ b/InstallerCA/InstallerCA.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>InstallerCA</RootNamespace>
     <AssemblyName>InstallerCA</AssemblyName>
-    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <WixCATargetsPath Condition=" '$(WixCATargetsPath)' == '' ">$(MSBuildExtensionsPath)\Microsoft\WiX\v3.x\Wix.CA.targets</WixCATargetsPath>
   </PropertyGroup>

--- a/scripts/Build-Installer.ps1
+++ b/scripts/Build-Installer.ps1
@@ -275,6 +275,7 @@ $msbuildArgs = @(
     $installerSln,
     '-nologo',
     '-verbosity:minimal',
+    '-p:Configuration=Release',
     '-p:RunWixToolsOutOfProc=true',
     '-p:DeployOnBuild=true',
     "-p:ReleaseType=$ReleaseType",

--- a/scripts/Build-Installer.ps1
+++ b/scripts/Build-Installer.ps1
@@ -83,10 +83,10 @@ Write-Host "CodeLocation:   $CodeLocation"
 Write-Host "InstallerRoot:  $installerRoot"
 Write-Host "::endgroup::"
 
-# Ensure the BHoM ProgramData directories exist — each dep repo's PostBuildEvent
-# xcopies its DLLs here. The WiX BeforeBuild target then xcopies from here into
-# the installer's working dir. If these directories don't exist, the build fails
-# in confusing ways.
+# Ensure the BHoM ProgramData directories exist. Each dep repo's PostBuildEvent
+# xcopies its DLLs here, and the WiX BeforeBuild target then xcopies from here
+# into the installer's working dir. Missing directories cause confusing build
+# failures further down.
 $bhomProgramData = Join-Path $env:ProgramData 'BHoM'
 foreach ($sub in @('Assemblies', 'DataSets', 'Settings', 'Extensions/PythonCode', 'Resources', 'GrasshopperPlugin', 'Upgrades')) {
     New-Item -ItemType Directory -Force -Path (Join-Path $bhomProgramData $sub) | Out-Null
@@ -121,9 +121,9 @@ function Clone-Repo {
 
     # --depth 1 keeps the runner fast; we don't need history for builds.
     # --branch $MainBranch ensures we land on develop (matches BHoMBot's
-    # DevelopBranchName for alpha builds). If the branch doesn't exist on a dep,
-    # the clone will fail loudly — surface this rather than silently using
-    # default branch.
+    # DevelopBranchName for alpha builds). If the branch does not exist on
+    # a dep, the clone is allowed to fail loudly so the issue is visible,
+    # rather than silently falling back to the default branch.
     git clone --depth 1 --branch $MainBranch "https://github.com/$OrgRepo.git" $target 2>&1 | ForEach-Object { Write-Host "  $_" }
     if ($LASTEXITCODE -ne 0) {
         Write-Host "::warning::Clone of $OrgRepo failed on branch '$MainBranch'; retrying with default branch"
@@ -140,7 +140,7 @@ function Build-Solution {
     )
 
     if (-not (Test-Path $SlnPath)) {
-        Write-Host "::warning::No solution at $SlnPath — skipping build"
+        Write-Host "::warning::No solution at $SlnPath. Skipping build."
         return
     }
 
@@ -218,12 +218,12 @@ function Build-Configs-FromFile {
 # ─── Clone + build the dependency graph (mirrors BHoMBot's CloneInstaller.cs) ─
 
 # Order matters: core first, then adapters, then UI, then deps, then includes,
-# etc. Some files are BHE-only and won't exist in the BHoM_Installer repo —
-# Clone-And-Build-FromFile handles missing files gracefully.
+# and so on. Some files are BHE-only and will not exist in the BHoM_Installer
+# repo; Clone-And-Build-FromFile handles missing files gracefully.
 #
-# BHoMBot parallelises some of these. For this initial iteration we run
-# sequentially — easier to debug, deterministic output. Parallelism is a
-# Phase 1.5 optimisation once the workflow is stable.
+# BHoMBot parallelises some of these groups. For this initial iteration we run
+# sequentially because it is easier to debug and produces deterministic output.
+# Parallelism is a Phase 1.5 optimisation once the workflow is stable.
 
 Clone-And-Build-FromFile -FileName 'core.txt'
 Clone-And-Build-FromFile -FileName 'adapterCore.txt'
@@ -238,10 +238,10 @@ Clone-And-Build-FromFile -FileName 'revitTools_Beta.txt'  # BHE-only, absent in 
 Build-Configs-FromFile -FileName 'altConfigs.txt'
 
 # NOTE: BHoMBot calls UpdateFixedRevitVersioningTypes() here (Revit API mocks
-# for the Versioning_Toolkit build) and a 60s sleep after versioning.
-# Skipped in this initial iteration — surfaces as a build failure if it turns
-# out to matter. Will add back if Versioning_Toolkit build fails or produces
-# incorrect output.
+# for the Versioning_Toolkit build), followed by a 60-second sleep after the
+# versioning step. Both are skipped in this initial iteration. If either turns
+# out to be load-bearing, the Versioning_Toolkit build will fail or produce
+# incorrect output, at which point we add them back.
 
 Clone-And-Build-FromFile -FileName 'versioning.txt'
 
@@ -294,7 +294,7 @@ Write-Host "::endgroup::"
 # at $installerRoot\..\Build\, which is $CodeLocation\Build\).
 $buildDir = Join-Path $CodeLocation 'Build'
 if (-not (Test-Path $buildDir)) {
-    # Fallback — some local builds put it under the installer root
+    # Fallback for local builds that put the output under the installer root.
     $buildDir = Join-Path $installerRoot 'Build'
     if (-not (Test-Path $buildDir)) {
         throw "No Build directory found at $CodeLocation\Build or $installerRoot\Build"

--- a/scripts/Build-Installer.ps1
+++ b/scripts/Build-Installer.ps1
@@ -275,7 +275,6 @@ $msbuildArgs = @(
     $installerSln,
     '-nologo',
     '-verbosity:minimal',
-    '-p:Configuration=Release',
     '-p:RunWixToolsOutOfProc=true',
     '-p:DeployOnBuild=true',
     "-p:ReleaseType=$ReleaseType",

--- a/scripts/Build-Installer.ps1
+++ b/scripts/Build-Installer.ps1
@@ -308,12 +308,19 @@ $sizeMB = [math]::Round($msi.Length / 1MB, 2)
 Write-Host "::notice::Installer built: $($msi.FullName) ($sizeMB MB)"
 
 # Also copy to GITHUB_WORKSPACE\Build\ so actions/upload-artifact finds it via
-# the workflow's static path (workspace-relative).
+# the workflow's static path (workspace-relative). Skip when MSBuild already
+# emitted the .msi into that exact directory (would otherwise raise
+# "Cannot overwrite the item with itself").
 if ($env:GITHUB_WORKSPACE) {
     $workspaceBuild = Join-Path $env:GITHUB_WORKSPACE 'Build'
     New-Item -ItemType Directory -Force -Path $workspaceBuild | Out-Null
-    Copy-Item $msi.FullName $workspaceBuild -Force
-    Write-Host "::notice::Copied to $workspaceBuild for artefact upload"
+    $workspaceBuildResolved = (Resolve-Path $workspaceBuild).Path
+    if ($msi.DirectoryName -ne $workspaceBuildResolved) {
+        Copy-Item $msi.FullName $workspaceBuild -Force
+        Write-Host "::notice::Copied to $workspaceBuild for artefact upload"
+    } else {
+        Write-Host "::notice::.msi already in $workspaceBuild, no copy needed"
+    }
 }
 
 # Expose outputs to the workflow

--- a/scripts/Build-Installer.ps1
+++ b/scripts/Build-Installer.ps1
@@ -1,0 +1,324 @@
+<#
+.SYNOPSIS
+    Builds the BHoM installer (alpha or beta).
+
+.DESCRIPTION
+    GitHub Actions port of BHoMBot's BuildAlpha + CloneInstaller orchestration.
+    Reads the installer's IncludedRepos/*.txt manifests in the same order BHoMBot
+    does, clones + builds each dependency repo, stages assemblies into
+    C:\ProgramData\BHoM\ via each repo's MSBuild PostBuildEvent, then invokes the
+    WiX installer build with the correct ReleaseType and PatchVersion properties.
+
+    This is a faithful port of the orchestration BHoMBot has been doing on its
+    on-premises server for years, NOT a port of the installer's existing
+    BuildSolution.ps1 + CloneAndBuildAllRequiredRepos.ps1 (those are used by the
+    Azure Pipelines path, which is being retired alongside BHoMBot).
+
+.PARAMETER ReleaseType
+    'alpha' or 'beta'. Drives the WiX ReleaseType property and whether
+    alphaIncludes.txt + alphaConfigs.txt are added to the clone set.
+
+.PARAMETER PatchVersion
+    Patch version, yyMMdd format. Defaults to today.
+
+.PARAMETER CodeLocation
+    Root directory where the installer repo and all deps are co-located. Defaults
+    to the parent of the script's repo (i.e. workspace parent on a GHA runner).
+
+.PARAMETER InstallerRepoName
+    Folder name of the installer repo within CodeLocation. Defaults to
+    BHoM_Installer. For BHE builds this would be BuroHappold_Installer (not yet
+    supported in this iteration).
+
+.PARAMETER MainBranch
+    Branch to clone each dep from. Defaults to 'develop' (matches BHoMBot's
+    DevelopBranchName for alpha builds).
+#>
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [ValidateSet('alpha', 'beta')]
+    [string]$ReleaseType,
+
+    [string]$PatchVersion,
+
+    [string]$CodeLocation,
+
+    [string]$InstallerRepoName = 'BHoM_Installer',
+
+    [string]$MainBranch = 'develop'
+)
+
+$ErrorActionPreference = 'Stop'
+
+# ─── Setup ───────────────────────────────────────────────────────────────────
+
+if (-not $CodeLocation) {
+    # Default: parent of the installer-repo checkout.
+    # Layout on GHA hosted runner:
+    #   D:\a\BHoM_Installer\                       ← CodeLocation
+    #   D:\a\BHoM_Installer\BHoM_Installer\        ← repo root (= GITHUB_WORKSPACE)
+    #   D:\a\BHoM_Installer\BHoM_Installer\scripts\Build-Installer.ps1
+    $scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+    $repoRoot  = Split-Path -Parent $scriptDir
+    $CodeLocation = Split-Path -Parent $repoRoot
+}
+
+if (-not $PatchVersion) {
+    $PatchVersion = (Get-Date).ToString('yyMMdd')
+}
+
+$installerRoot = Join-Path $CodeLocation $InstallerRepoName
+$manifestDir   = Join-Path $installerRoot 'IncludedRepos'
+
+if (-not (Test-Path $installerRoot)) { throw "Installer repo not found at: $installerRoot" }
+if (-not (Test-Path $manifestDir))   { throw "Manifest directory not found at: $manifestDir" }
+
+Write-Host "::group::Build configuration"
+Write-Host "ReleaseType:    $ReleaseType"
+Write-Host "PatchVersion:   $PatchVersion"
+Write-Host "MainBranch:     $MainBranch"
+Write-Host "CodeLocation:   $CodeLocation"
+Write-Host "InstallerRoot:  $installerRoot"
+Write-Host "::endgroup::"
+
+# Ensure the BHoM ProgramData directories exist — each dep repo's PostBuildEvent
+# xcopies its DLLs here. The WiX BeforeBuild target then xcopies from here into
+# the installer's working dir. If these directories don't exist, the build fails
+# in confusing ways.
+$bhomProgramData = Join-Path $env:ProgramData 'BHoM'
+foreach ($sub in @('Assemblies', 'DataSets', 'Settings', 'Extensions/PythonCode', 'Resources', 'GrasshopperPlugin', 'Upgrades')) {
+    New-Item -ItemType Directory -Force -Path (Join-Path $bhomProgramData $sub) | Out-Null
+}
+
+# ─── Toolchain discovery ─────────────────────────────────────────────────────
+
+$vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+if (-not (Test-Path $vswhere)) { throw "vswhere.exe not found at $vswhere" }
+
+$msbuild = & $vswhere -latest -requires Microsoft.Component.MSBuild -find "MSBuild\**\Bin\MSBuild.exe" | Select-Object -First 1
+if (-not $msbuild) { throw "MSBuild not located via vswhere" }
+Write-Host "::notice::MSBuild → $msbuild"
+
+$nuget = (Get-Command nuget.exe -ErrorAction SilentlyContinue)?.Source
+if (-not $nuget) { throw "nuget.exe not on PATH" }
+Write-Host "::notice::NuGet → $nuget"
+
+# ─── Helpers ────────────────────────────────────────────────────────────────
+
+function Clone-Repo {
+    param([string]$OrgRepo)
+
+    $parts  = $OrgRepo.Split('/')
+    $name   = $parts[1]
+    $target = Join-Path $CodeLocation $name
+
+    if (Test-Path (Join-Path $target '.git')) {
+        Write-Host "  [skip clone] $name already present"
+        return $target
+    }
+
+    # --depth 1 keeps the runner fast; we don't need history for builds.
+    # --branch $MainBranch ensures we land on develop (matches BHoMBot's
+    # DevelopBranchName for alpha builds). If the branch doesn't exist on a dep,
+    # the clone will fail loudly — surface this rather than silently using
+    # default branch.
+    git clone --depth 1 --branch $MainBranch "https://github.com/$OrgRepo.git" $target 2>&1 | ForEach-Object { Write-Host "  $_" }
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "::warning::Clone of $OrgRepo failed on branch '$MainBranch'; retrying with default branch"
+        git clone --depth 1 "https://github.com/$OrgRepo.git" $target 2>&1 | ForEach-Object { Write-Host "  $_" }
+        if ($LASTEXITCODE -ne 0) { throw "git clone failed for $OrgRepo" }
+    }
+    return $target
+}
+
+function Build-Solution {
+    param(
+        [string]$SlnPath,
+        [string]$Config = 'Release'
+    )
+
+    if (-not (Test-Path $SlnPath)) {
+        Write-Host "::warning::No solution at $SlnPath — skipping build"
+        return
+    }
+
+    & $nuget restore $SlnPath -Verbosity quiet
+    if ($LASTEXITCODE -ne 0) { throw "NuGet restore failed for $SlnPath" }
+
+    & $msbuild $SlnPath -nologo -verbosity:minimal "-p:Configuration=$Config"
+    if ($LASTEXITCODE -ne 0) { throw "MSBuild failed for $SlnPath (config=$Config)" }
+}
+
+function Clone-And-Build-FromFile {
+    param([string]$FileName)
+
+    $manifest = Join-Path $manifestDir $FileName
+    if (-not (Test-Path $manifest)) {
+        Write-Host "  [skip manifest] $FileName not present (this is expected for BHE-only files in the BHoM installer)"
+        return
+    }
+
+    $repos = Get-Content $manifest |
+             Where-Object { $_ -and -not $_.StartsWith('#') } |
+             ForEach-Object { $_.Trim() } |
+             Where-Object { $_ }
+
+    if ($repos.Count -eq 0) {
+        Write-Host "  [empty] $FileName has no entries"
+        return
+    }
+
+    Write-Host "::group::$FileName ($($repos.Count) repos)"
+    foreach ($repo in $repos) {
+        Write-Host "----- $repo -----"
+        $target = Clone-Repo -OrgRepo $repo
+        $sln    = Join-Path $target "$(Split-Path -Leaf $target).sln"
+        Build-Solution -SlnPath $sln
+    }
+    Write-Host "::endgroup::"
+}
+
+function Build-Configs-FromFile {
+    param([string]$FileName)
+
+    $manifest = Join-Path $manifestDir $FileName
+    if (-not (Test-Path $manifest)) {
+        Write-Host "  [skip configs] $FileName not present"
+        return
+    }
+
+    $entries = Get-Content $manifest |
+               Where-Object { $_ -and -not $_.StartsWith('#') } |
+               ForEach-Object { $_.Trim() } |
+               Where-Object { $_ }
+
+    if ($entries.Count -eq 0) { return }
+
+    Write-Host "::group::$FileName ($($entries.Count) configs)"
+    foreach ($entry in $entries) {
+        $parts = $entry.Split('/')
+        if ($parts.Length -lt 3) {
+            Write-Host "::warning::Malformed altConfigs entry (need org/repo/Config): $entry"
+            continue
+        }
+        $orgRepo = "$($parts[0])/$($parts[1])"
+        $config  = $parts[2]
+        $name    = $parts[1]
+
+        Write-Host "----- $orgRepo @ $config -----"
+        $target = Clone-Repo -OrgRepo $orgRepo
+        $sln    = Join-Path $target "$name.sln"
+        Build-Solution -SlnPath $sln -Config $config
+    }
+    Write-Host "::endgroup::"
+}
+
+# ─── Clone + build the dependency graph (mirrors BHoMBot's CloneInstaller.cs) ─
+
+# Order matters: core first, then adapters, then UI, then deps, then includes,
+# etc. Some files are BHE-only and won't exist in the BHoM_Installer repo —
+# Clone-And-Build-FromFile handles missing files gracefully.
+#
+# BHoMBot parallelises some of these. For this initial iteration we run
+# sequentially — easier to debug, deterministic output. Parallelism is a
+# Phase 1.5 optimisation once the workflow is stable.
+
+Clone-And-Build-FromFile -FileName 'core.txt'
+Clone-And-Build-FromFile -FileName 'adapterCore.txt'
+Clone-And-Build-FromFile -FileName 'uiCore.txt'
+Clone-And-Build-FromFile -FileName 'dependencies.txt'
+Clone-And-Build-FromFile -FileName 'include.txt'
+Clone-And-Build-FromFile -FileName 'userInterfaces.txt'
+Clone-And-Build-FromFile -FileName 'analytics.txt'        # BHE-only, absent in BHoM_Installer
+Clone-And-Build-FromFile -FileName 'zeroCode.txt'         # BHE-only, absent in BHoM_Installer
+Clone-And-Build-FromFile -FileName 'revitTools_Beta.txt'  # BHE-only, absent in BHoM_Installer
+
+Build-Configs-FromFile -FileName 'altConfigs.txt'
+
+# NOTE: BHoMBot calls UpdateFixedRevitVersioningTypes() here (Revit API mocks
+# for the Versioning_Toolkit build) and a 60s sleep after versioning.
+# Skipped in this initial iteration — surfaces as a build failure if it turns
+# out to matter. Will add back if Versioning_Toolkit build fails or produces
+# incorrect output.
+
+Clone-And-Build-FromFile -FileName 'versioning.txt'
+
+if ($ReleaseType -eq 'alpha') {
+    Clone-And-Build-FromFile -FileName 'alphaIncludes.txt'
+    Build-Configs-FromFile   -FileName 'alphaConfigs.txt'
+}
+
+# ─── Write IncludedDLLs.txt (mirrors BHoMBot's SaveIncludedDLLs.cs) ─────────
+
+$assembliesDir   = Join-Path $bhomProgramData 'Assemblies'
+$dlls            = Get-ChildItem $assembliesDir -Filter '*.dll' -ErrorAction SilentlyContinue | Select-Object -ExpandProperty FullName
+$settingsDir     = Join-Path $installerRoot 'Settings'
+$includedDllsTxt = Join-Path $settingsDir 'IncludedDLLs.txt'
+
+New-Item -ItemType Directory -Force -Path $settingsDir | Out-Null
+$dlls | Set-Content $includedDllsTxt
+Write-Host "::notice::Wrote $($dlls.Count) DLLs to $includedDllsTxt"
+
+# ─── Build the installer .sln itself ────────────────────────────────────────
+
+$installerSln = Join-Path $installerRoot "$InstallerRepoName.sln"
+if (-not (Test-Path $installerSln)) { throw "Installer solution not found at $installerSln" }
+
+Write-Host "::group::Build installer ($ReleaseType, patch=$PatchVersion)"
+
+& $nuget restore $installerSln
+if ($LASTEXITCODE -ne 0) { throw "NuGet restore failed for installer solution" }
+
+$msbuildArgs = @(
+    $installerSln,
+    '-nologo',
+    '-verbosity:minimal',
+    '-p:RunWixToolsOutOfProc=true',
+    '-p:DeployOnBuild=true',
+    "-p:ReleaseType=$ReleaseType",
+    "-p:PatchVersion=$PatchVersion",
+    '-p:WebPublishMethod=Package',
+    '-p:PackageAsSingleFile=true',
+    '-p:SkipInvalidConfigurations=true'
+)
+& $msbuild @msbuildArgs
+if ($LASTEXITCODE -ne 0) { throw "MSBuild failed for installer solution" }
+
+Write-Host "::endgroup::"
+
+# ─── Locate output .msi ─────────────────────────────────────────────────────
+
+# BHoM_Installer.wixproj puts output at ../Build/ relative to the .sln (i.e.
+# at $installerRoot\..\Build\, which is $CodeLocation\Build\).
+$buildDir = Join-Path $CodeLocation 'Build'
+if (-not (Test-Path $buildDir)) {
+    # Fallback — some local builds put it under the installer root
+    $buildDir = Join-Path $installerRoot 'Build'
+    if (-not (Test-Path $buildDir)) {
+        throw "No Build directory found at $CodeLocation\Build or $installerRoot\Build"
+    }
+}
+
+$msi = Get-ChildItem $buildDir -Filter '*.msi' -ErrorAction SilentlyContinue | Select-Object -First 1
+if (-not $msi) { throw "No .msi produced in $buildDir" }
+
+$sizeMB = [math]::Round($msi.Length / 1MB, 2)
+Write-Host "::notice::Installer built: $($msi.FullName) ($sizeMB MB)"
+
+# Also copy to GITHUB_WORKSPACE\Build\ so actions/upload-artifact finds it via
+# the workflow's static path (workspace-relative).
+if ($env:GITHUB_WORKSPACE) {
+    $workspaceBuild = Join-Path $env:GITHUB_WORKSPACE 'Build'
+    New-Item -ItemType Directory -Force -Path $workspaceBuild | Out-Null
+    Copy-Item $msi.FullName $workspaceBuild -Force
+    Write-Host "::notice::Copied to $workspaceBuild for artefact upload"
+}
+
+# Expose outputs to the workflow
+if ($env:GITHUB_OUTPUT) {
+    "installer_path=$($msi.FullName)" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+    "installer_name=$($msi.Name)"     | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+    "installer_size_mb=$sizeMB"        | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+}

--- a/scripts/compose-release-body.sh
+++ b/scripts/compose-release-body.sh
@@ -3,11 +3,19 @@
 #
 # Reads inputs from environment variables and writes the final body to
 # release-body.md in the current working directory. The body is composed
-# of two parts:
-#   1. A short preamble (this script) with build provenance and a link
-#      to the diff base release.
-#   2. The dependency-change section produced by generate_release_notes.py
+# of three parts:
+#   1. A short preamble with build provenance.
+#   2. A per-environment Test results table, populated from the workflow's
+#      Jobs API so it picks up every matrix leg automatically.
+#   3. The dependency-change section produced by generate_release_notes.py
 #      and read from release-notes-section.md.
+#
+# This script is only invoked when the publish gate (success() on all
+# dependent jobs) passed. Test results will therefore always show
+# 'Passed' in current behaviour, but the table form lets users see
+# which environments were exercised and click through to the per-leg job.
+# If we later add matrix legs (for example windows-11), they will
+# appear automatically without further changes here.
 #
 # Required environment:
 #   GITHUB_SERVER_URL    Provided by GitHub Actions.
@@ -15,7 +23,7 @@
 #   GITHUB_RUN_ID        Provided by GitHub Actions.
 #   GITHUB_SHA           Provided by GitHub Actions.
 #   GITHUB_EVENT_NAME    Provided by GitHub Actions.
-#   INSTALL_TEST_RESULT  'success', 'failure', 'skipped', or 'cancelled'.
+#   GH_TOKEN             Token with 'actions: read' on the repo.
 #   PREV_TAG             Prior alpha release tag for the diff base, or
 #                        empty string if no prior release exists.
 #
@@ -28,16 +36,38 @@ set -eu
 
 run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
 
-if [ "$INSTALL_TEST_RESULT" = "success" ]; then
-    test_status="Passed install and uninstall smoke tests on windows-2022 and windows-2025."
-else
-    test_status="Smoke test result: \`$INSTALL_TEST_RESULT\`. See [run logs]($run_url) for details. This build is provided for diagnostic and local testing only and should not be promoted to users."
-fi
-
 if [ -n "$PREV_TAG" ]; then
     diff_note="Changes are computed against [\`$PREV_TAG\`](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/releases/tag/${PREV_TAG})."
 else
     diff_note="No prior alpha release was found, so this build is published as an initial baseline."
+fi
+
+# Per-OS test results from the workflow's Jobs API. Filter to install-test
+# matrix legs by name prefix; matrix substitution renders as
+# "Install + uninstall (windows-2022)" etc.
+jobs_json=$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID/jobs" --paginate)
+test_results_rows=$(echo "$jobs_json" | jq -r '
+    .jobs
+    | map(select(.name | startswith("Install + uninstall (")))
+    | sort_by(.name)
+    | map(
+        "| " + (.name | sub("Install \\+ uninstall \\("; "") | sub("\\)$"; ""))
+        + " | ["
+        + (
+            if .conclusion == "success" then "Passed"
+            elif .conclusion == "failure" then "Failed"
+            elif .conclusion == "skipped" then "Skipped"
+            elif .conclusion == "cancelled" then "Cancelled"
+            else .conclusion
+            end
+          )
+        + "](" + .html_url + ") |"
+      )
+    | .[]
+')
+
+if [ -z "$test_results_rows" ]; then
+    test_results_rows="| (no matrix legs detected) | |"
 fi
 
 cat >release-body.md <<EOF
@@ -50,7 +80,12 @@ Pre-release build of the BHoM installer produced by the alpha CI pipeline. See t
 | Build | [#${GITHUB_RUN_ID}]($run_url) |
 | Commit | \`${GITHUB_SHA}\` |
 | Triggered by | \`${GITHUB_EVENT_NAME}\` |
-| Test status | $test_status |
+
+### Test results
+
+| Environment | Result |
+|---|---|
+${test_results_rows}
 
 ### Changes
 

--- a/scripts/compose-release-body.sh
+++ b/scripts/compose-release-body.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Compose the release body for the publish-alpha workflow job.
+#
+# Reads inputs from environment variables and writes the final body to
+# release-body.md in the current working directory. The body is composed
+# of two parts:
+#   1. A short preamble (this script) with build provenance and a link
+#      to the diff base release.
+#   2. The dependency-change section produced by generate_release_notes.py
+#      and read from release-notes-section.md.
+#
+# Required environment:
+#   GITHUB_SERVER_URL    Provided by GitHub Actions.
+#   GITHUB_REPOSITORY    Provided by GitHub Actions.
+#   GITHUB_RUN_ID        Provided by GitHub Actions.
+#   GITHUB_SHA           Provided by GitHub Actions.
+#   GITHUB_EVENT_NAME    Provided by GitHub Actions.
+#   INSTALL_TEST_RESULT  'success', 'failure', 'skipped', or 'cancelled'.
+#   PREV_TAG             Prior alpha release tag for the diff base, or
+#                        empty string if no prior release exists.
+#
+# Required local file:
+#   release-notes-section.md  Output from generate_release_notes.py.
+#
+# Output:
+#   release-body.md           Final body, ready for softprops/action-gh-release.
+set -eu
+
+run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+
+if [ "$INSTALL_TEST_RESULT" = "success" ]; then
+    test_status="Passed install and uninstall smoke tests on windows-2022 and windows-2025."
+else
+    test_status="Smoke test result: \`$INSTALL_TEST_RESULT\`. See [run logs]($run_url) for details. This build is provided for diagnostic and local testing only and should not be promoted to users."
+fi
+
+if [ -n "$PREV_TAG" ]; then
+    diff_note="Changes are computed against [\`$PREV_TAG\`](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/releases/tag/${PREV_TAG})."
+else
+    diff_note="No prior alpha release was found, so this build is published as an initial baseline."
+fi
+
+cat >release-body.md <<EOF
+Pre-release build of the BHoM installer produced by the alpha CI pipeline. See the build provenance below before installing.
+
+### Build provenance
+
+| Field | Value |
+|---|---|
+| Build | [#${GITHUB_RUN_ID}]($run_url) |
+| Commit | \`${GITHUB_SHA}\` |
+| Triggered by | \`${GITHUB_EVENT_NAME}\` |
+| Test status | $test_status |
+
+### Changes
+
+$diff_note
+
+EOF
+cat release-notes-section.md >> release-body.md
+
+echo ""
+echo "=== Release body preview (first 80 lines) ==="
+head -80 release-body.md

--- a/scripts/compose-release-body.sh
+++ b/scripts/compose-release-body.sh
@@ -18,6 +18,7 @@
 # appear automatically without further changes here.
 #
 # Required environment:
+#   BUILT_AT             ISO8601 UTC timestamp from dep-manifest.json's built_at field.
 #   GITHUB_SERVER_URL    Provided by GitHub Actions.
 #   GITHUB_REPOSITORY    Provided by GitHub Actions.
 #   GITHUB_RUN_ID        Provided by GitHub Actions.
@@ -90,6 +91,7 @@ ${intro}
 | Field | Value |
 |---|---|
 | Build | [#${GITHUB_RUN_ID}]($run_url) |
+| Built at | \`${BUILT_AT}\` |
 | Commit | \`${GITHUB_SHA}\` |
 | Triggered by | \`${GITHUB_EVENT_NAME}\` |
 

--- a/scripts/compose-release-body.sh
+++ b/scripts/compose-release-body.sh
@@ -18,25 +18,25 @@
 # appear automatically without further changes here.
 #
 # Required environment:
-#   ANCHOR_TAG           Anchor for the diff section. Empty when ANCHOR_KIND=none.
-#   ANCHOR_KIND          'stable' or 'none', from find-previous-release.sh.
 #   SOURCE_BRANCH        Source branch that built this artefact, from resolve.
+#   GITHUB_EVENT_NAME    Provided by GitHub Actions. Used to detect non-canonical workflow_dispatch.
 #   BUILT_AT             ISO8601 UTC timestamp from dep-manifest.json's built_at field.
 #   GITHUB_SERVER_URL    Provided by GitHub Actions.
 #   GITHUB_REPOSITORY    Provided by GitHub Actions.
 #   GITHUB_RUN_ID        Provided by GitHub Actions.
 #   GITHUB_SHA           Provided by GitHub Actions.
-#   GITHUB_EVENT_NAME    Provided by GitHub Actions.
 #   GH_TOKEN             Token with 'actions: read' on the repo.
 #   RELEASE_TYPE         'alpha' or 'beta'. Drives the intro sentence.
 #   IS_PRERELEASE        'true' or 'false'. Drives the intro sentence.
 #
 # Optional local file:
-#   release-notes-section.md  Output from generate_release_notes.py. Required
-#                             only when the canonical render branch fires.
+#   release-notes-section.md  Output from generate_release_notes.py.
+#                             Required when the canonical render branch fires
+#                             (i.e. when source_branch=develop). Otherwise the
+#                             non-canonical warning block is emitted instead.
 #
 # Output:
-#   release-body.md           Final body, ready for softprops/action-gh-release.
+#   release-body.md      Final body, ready for softprops/action-gh-release.
 set -eu
 
 run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"

--- a/scripts/compose-release-body.sh
+++ b/scripts/compose-release-body.sh
@@ -18,6 +18,9 @@
 # appear automatically without further changes here.
 #
 # Required environment:
+#   ANCHOR_TAG           Anchor for the diff section. Empty when ANCHOR_KIND=none.
+#   ANCHOR_KIND          'stable' or 'none', from find-previous-release.sh.
+#   SOURCE_BRANCH        Source branch that built this artefact, from resolve.
 #   BUILT_AT             ISO8601 UTC timestamp from dep-manifest.json's built_at field.
 #   GITHUB_SERVER_URL    Provided by GitHub Actions.
 #   GITHUB_REPOSITORY    Provided by GitHub Actions.
@@ -27,11 +30,10 @@
 #   GH_TOKEN             Token with 'actions: read' on the repo.
 #   RELEASE_TYPE         'alpha' or 'beta'. Drives the intro sentence.
 #   IS_PRERELEASE        'true' or 'false'. Drives the intro sentence.
-#   PREV_TAG             Prior release tag for the diff base, or empty
-#                        string if no prior release exists.
 #
-# Required local file:
-#   release-notes-section.md  Output from generate_release_notes.py.
+# Optional local file:
+#   release-notes-section.md  Output from generate_release_notes.py. Required
+#                             only when the canonical render branch fires.
 #
 # Output:
 #   release-body.md           Final body, ready for softprops/action-gh-release.
@@ -39,25 +41,29 @@ set -eu
 
 run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
 
-if [ -n "$PREV_TAG" ]; then
-    diff_note="Changes are computed against [\`$PREV_TAG\`](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/releases/tag/${PREV_TAG})."
-else
-    diff_note="No prior release was found, so this build is published as an initial baseline."
+# Decide whether this build is on the canonical lineage. Non-canonical means
+# the user dispatched with a non-develop source_branch. push events (final
+# releases) always use main, but that is the canonical final-release path;
+# only workflow_dispatch with non-develop is treated as non-canonical.
+is_non_canonical="false"
+if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ] && [ "${SOURCE_BRANCH}" != "develop" ]; then
+    is_non_canonical="true"
 fi
 
-# Intro sentence varies by release flavour. Three cases:
-#   alpha prerelease      'Pre-release alpha build of the BHoM installer...'
-#   beta prerelease       'Pre-release beta build of the BHoM installer...'
-#   beta release (tag)    'Release build of the BHoM installer...'
+# Intro sentence varies by flavour.
 if [ "$IS_PRERELEASE" = "true" ]; then
     intro="Pre-release ${RELEASE_TYPE} build of the BHoM installer produced by the CI pipeline. See the build provenance below before installing."
 else
     intro="Release build of the BHoM installer produced by the CI pipeline from a tagged commit on main."
 fi
 
-# Per-OS test results from the workflow's Jobs API. Filter to install-test
-# matrix legs by name prefix; matrix substitution renders as
-# "Install + uninstall (windows-2022)" etc.
+# Optional "Source branch" provenance row, only when non-canonical.
+source_branch_row=""
+if [ "$is_non_canonical" = "true" ]; then
+    source_branch_row="| Source branch | \`${SOURCE_BRANCH}\` |"
+fi
+
+# Per-OS test results from the workflow's Jobs API.
 jobs_json=$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID/jobs" --paginate)
 test_results_rows=$(echo "$jobs_json" | jq -r '
     .jobs
@@ -83,6 +89,7 @@ if [ -z "$test_results_rows" ]; then
     test_results_rows="| (no matrix legs detected) | |"
 fi
 
+# Compose the head of the body.
 cat >release-body.md <<EOF
 ${intro}
 
@@ -94,6 +101,7 @@ ${intro}
 | Built at | \`${BUILT_AT}\` |
 | Commit | \`${GITHUB_SHA}\` |
 | Triggered by | \`${GITHUB_EVENT_NAME}\` |
+${source_branch_row}
 
 ### Test results
 
@@ -101,12 +109,25 @@ ${intro}
 |---|---|
 ${test_results_rows}
 
-### Changes
-
-$diff_note
-
 EOF
-cat release-notes-section.md >> release-body.md
+
+# Three render branches for the diff section.
+if [ "$is_non_canonical" = "true" ]; then
+    # Warning block. No diff section.
+    cat >>release-body.md <<EOF
+> Non-default source branch. This build was produced from \`${SOURCE_BRANCH}\`, not \`develop\`. The changelog is omitted because a build from \`${SOURCE_BRANCH}\` cannot be compared meaningfully against develop-sourced releases.
+>
+> Dependency branches and commit SHAs are recorded in the attached \`dep-manifest.json\`. For develop-sourced builds, see the [releases page](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/releases).
+EOF
+else
+    # Canonical path. The python script emits its own heading
+    # (### Changes since {anchor} or ### Initial release).
+    if [ -f release-notes-section.md ]; then
+        cat release-notes-section.md >> release-body.md
+    else
+        printf '### Initial release\n\nNo dependency diff section was produced for this build.\n' >> release-body.md
+    fi
+fi
 
 echo ""
 echo "=== Release body preview (first 80 lines) ==="

--- a/scripts/compose-release-body.sh
+++ b/scripts/compose-release-body.sh
@@ -24,8 +24,10 @@
 #   GITHUB_SHA           Provided by GitHub Actions.
 #   GITHUB_EVENT_NAME    Provided by GitHub Actions.
 #   GH_TOKEN             Token with 'actions: read' on the repo.
-#   PREV_TAG             Prior alpha release tag for the diff base, or
-#                        empty string if no prior release exists.
+#   RELEASE_TYPE         'alpha' or 'beta'. Drives the intro sentence.
+#   IS_PRERELEASE        'true' or 'false'. Drives the intro sentence.
+#   PREV_TAG             Prior release tag for the diff base, or empty
+#                        string if no prior release exists.
 #
 # Required local file:
 #   release-notes-section.md  Output from generate_release_notes.py.
@@ -39,7 +41,17 @@ run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}
 if [ -n "$PREV_TAG" ]; then
     diff_note="Changes are computed against [\`$PREV_TAG\`](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/releases/tag/${PREV_TAG})."
 else
-    diff_note="No prior alpha release was found, so this build is published as an initial baseline."
+    diff_note="No prior release was found, so this build is published as an initial baseline."
+fi
+
+# Intro sentence varies by release flavour. Three cases:
+#   alpha prerelease      'Pre-release alpha build of the BHoM installer...'
+#   beta prerelease       'Pre-release beta build of the BHoM installer...'
+#   beta release (tag)    'Release build of the BHoM installer...'
+if [ "$IS_PRERELEASE" = "true" ]; then
+    intro="Pre-release ${RELEASE_TYPE} build of the BHoM installer produced by the CI pipeline. See the build provenance below before installing."
+else
+    intro="Release build of the BHoM installer produced by the CI pipeline from a tagged commit on main."
 fi
 
 # Per-OS test results from the workflow's Jobs API. Filter to install-test
@@ -71,7 +83,7 @@ if [ -z "$test_results_rows" ]; then
 fi
 
 cat >release-body.md <<EOF
-Pre-release build of the BHoM installer produced by the alpha CI pipeline. See the build provenance below before installing.
+${intro}
 
 ### Build provenance
 

--- a/scripts/find-previous-release.sh
+++ b/scripts/find-previous-release.sh
@@ -64,9 +64,61 @@ parse_release_tag() {
 # Reads REQ_M, REQ_N, REQ_P, REQ_IS_PRERELEASE set by parse_release_tag.
 # Writes anchor_tag and anchor_kind to stdout as KEY=VALUE pairs.
 select_anchor() {
-    # Stub. Implemented in Task 2.
-    printf 'anchor_tag=\n'
-    printf 'anchor_kind=none\n'
+    local current_tag="$1"
+    local m="$REQ_M" n="$REQ_N" p="$REQ_P"
+    local is_prerelease="$REQ_IS_PRERELEASE"
+
+    # Collect stable candidates from lookup_releases, parsed as (M N P tag) rows.
+    local candidates=()
+    local tag stable_m stable_n stable_p
+    while IFS= read -r tag; do
+        [ -z "$tag" ] && continue
+        [ "$tag" = "$current_tag" ] && continue   # Self-exclusion
+        if read -r stable_m stable_n stable_p < <(parse_stable_tag "$tag" 2>/dev/null); then
+            candidates+=("$stable_m $stable_n $stable_p $tag")
+        fi
+    done < <(lookup_releases)
+
+    if [ "${#candidates[@]}" -eq 0 ]; then
+        printf 'anchor_tag=\n'
+        printf 'anchor_kind=none\n'
+        return 0
+    fi
+
+    # Rule A: pre-releases and v{M}.{N}.0 finals.
+    # Filter to candidates strictly below the current M.N, then pick the
+    # SemVer-highest (M', N', P') tuple.
+    local best_m=-1 best_n=-1 best_p=-1 best_tag=""
+    local c c_m c_n c_p c_tag
+    for c in "${candidates[@]}"; do
+        # shellcheck disable=SC2206
+        local parts=($c)
+        c_m="${parts[0]}"
+        c_n="${parts[1]}"
+        c_p="${parts[2]}"
+        c_tag="${parts[3]}"
+        # Strict (M', N') < (M, N).
+        if [ "$c_m" -lt "$m" ] \
+           || { [ "$c_m" -eq "$m" ] && [ "$c_n" -lt "$n" ]; }; then
+            # SemVer-descending pick.
+            if [ "$c_m" -gt "$best_m" ] \
+               || { [ "$c_m" -eq "$best_m" ] && [ "$c_n" -gt "$best_n" ]; } \
+               || { [ "$c_m" -eq "$best_m" ] && [ "$c_n" -eq "$best_n" ] && [ "$c_p" -gt "$best_p" ]; }; then
+                best_m="$c_m"
+                best_n="$c_n"
+                best_p="$c_p"
+                best_tag="$c_tag"
+            fi
+        fi
+    done
+
+    if [ -n "$best_tag" ]; then
+        printf 'anchor_tag=%s\n' "$best_tag"
+        printf 'anchor_kind=stable\n'
+    else
+        printf 'anchor_tag=\n'
+        printf 'anchor_kind=none\n'
+    fi
 }
 
 main() {
@@ -102,6 +154,27 @@ self_test() {
         "$(echo "$out" | grep '^anchor_kind=')"
     assert_equal "case 1: no prior stable -> anchor_tag empty" \
         "anchor_tag=" \
+        "$(echo "$out" | grep '^anchor_tag=')"
+
+    # Case 2: v9.1.0 prior -> v9.1.0
+    lookup_releases() { printf '%s\n' "v9.1.0"; }
+    out=$(main "v9.2.0-alpha.260605")
+    assert_equal "case 2: v9.1.0 prior -> v9.1.0" \
+        "anchor_tag=v9.1.0" \
+        "$(echo "$out" | grep '^anchor_tag=')"
+
+    # Case 3: v9.1.0 + v9.1.2 prior -> v9.1.2 (highest patch in M.N wins)
+    lookup_releases() { printf '%s\n' "v9.1.0" "v9.1.2"; }
+    out=$(main "v9.2.0-alpha.260605")
+    assert_equal "case 3: v9.1.0 and v9.1.2 prior -> v9.1.2" \
+        "anchor_tag=v9.1.2" \
+        "$(echo "$out" | grep '^anchor_tag=')"
+
+    # Case 12: SemVer sort beats back-port publish order
+    lookup_releases() { printf '%s\n' "v9.1.3" "v9.2.0" "v9.1.0"; }
+    out=$(main "v9.3.0-alpha.260801")
+    assert_equal "case 12: SemVer sort beats back-port publish order" \
+        "anchor_tag=v9.2.0" \
         "$(echo "$out" | grep '^anchor_tag=')"
 
     echo

--- a/scripts/find-previous-release.sh
+++ b/scripts/find-previous-release.sh
@@ -177,6 +177,41 @@ self_test() {
         "anchor_tag=v9.2.0" \
         "$(echo "$out" | grep '^anchor_tag=')"
 
+    # Case 4: ignores alpha/beta tags as candidates
+    lookup_releases() { printf '%s\n' "v9.1.0-alpha.260101" "v9.1.0-beta.1" "v9.1.0"; }
+    out=$(main "v9.2.0-alpha.260605")
+    assert_equal "case 4: only stable tags are candidates" \
+        "anchor_tag=v9.1.0" \
+        "$(echo "$out" | grep '^anchor_tag=')"
+
+    # Case 5: final v9.2.0 with v9.1.0 + v9.1.2 prior -> v9.1.2
+    lookup_releases() { printf '%s\n' "v9.1.0" "v9.1.2"; }
+    out=$(main "v9.2.0")
+    assert_equal "case 5: final v9.2.0 anchors against v9.1.2" \
+        "anchor_tag=v9.1.2" \
+        "$(echo "$out" | grep '^anchor_tag=')"
+
+    # Case 9: current tag never anchored to itself
+    lookup_releases() { printf '%s\n' "v9.2.0-alpha.260605" "v9.1.0"; }
+    out=$(main "v9.2.0-alpha.260605")
+    assert_equal "case 9: self never returned as anchor" \
+        "anchor_tag=v9.1.0" \
+        "$(echo "$out" | grep '^anchor_tag=')"
+
+    # Case 10: double-digit version
+    lookup_releases() { printf '%s\n' "v10.13.5"; }
+    out=$(main "v10.14.0-alpha.270101")
+    assert_equal "case 10: double-digit version anchors correctly" \
+        "anchor_tag=v10.13.5" \
+        "$(echo "$out" | grep '^anchor_tag=')"
+
+    # Case 11: v9.3.0-alpha with v9.2.5 latest stable -> v9.2.5
+    lookup_releases() { printf '%s\n' "v9.2.0" "v9.2.5" "v9.1.0"; }
+    out=$(main "v9.3.0-alpha.260801")
+    assert_equal "case 11: v9.3.0-alpha anchors against highest M.N stable v9.2.5" \
+        "anchor_tag=v9.2.5" \
+        "$(echo "$out" | grep '^anchor_tag=')"
+
     echo
     echo "Results: $pass passed, $fail failed"
     [ "$fail" -eq 0 ]

--- a/scripts/find-previous-release.sh
+++ b/scripts/find-previous-release.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# Resolve the anchor tag for the release body's "Changes since {anchor}" section.
+#
+# Given the release tag being published and the set of existing releases,
+# returns the anchor tag and a kind label. Pure function: source_branch
+# handling is done at render time in compose-release-body.sh, not here.
+#
+# Inputs (env):
+#   GITHUB_REPOSITORY    For gh API calls.
+#   GH_TOKEN             For gh API calls. Workflow's github.token is sufficient.
+#
+# Outputs (stdout, KEY=VALUE, intended for $GITHUB_OUTPUT):
+#   anchor_tag=v9.1.2    (empty when anchor_kind=none)
+#   anchor_kind=stable|none
+#
+# Exit codes:
+#   0  success
+#   3  missing input or internal error
+
+set -euo pipefail
+
+err() { printf '::error::%s\n' "$*" >&2; }
+
+# Override hook for tests. Returns the unsorted set of release tags on stdout.
+# SemVer sorting happens in select_anchor, not here.
+lookup_releases() {
+    gh release list --repo "${GITHUB_REPOSITORY}" --limit 100 \
+        --json tagName --jq '.[].tagName'
+}
+
+# Parse a stable tag (vM.N.P) into M N P components.
+# Returns non-zero on a non-stable tag.
+parse_stable_tag() {
+    local tag="$1"
+    if [[ "$tag" =~ ^v([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+        printf '%s %s %s\n' "${BASH_REMATCH[1]}" "${BASH_REMATCH[2]}" "${BASH_REMATCH[3]}"
+        return 0
+    fi
+    return 1
+}
+
+# Parse the release tag being published. Sets globals REQ_M, REQ_N, REQ_P,
+# REQ_IS_PRERELEASE.
+parse_release_tag() {
+    local tag="$1"
+    if [[ "$tag" =~ ^v([0-9]+)\.([0-9]+)\.([0-9]+)-(alpha|beta)(\.[0-9a-zA-Z.]+)?$ ]]; then
+        REQ_M="${BASH_REMATCH[1]}"
+        REQ_N="${BASH_REMATCH[2]}"
+        REQ_P="${BASH_REMATCH[3]}"
+        REQ_IS_PRERELEASE=true
+        return 0
+    elif [[ "$tag" =~ ^v([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+        REQ_M="${BASH_REMATCH[1]}"
+        REQ_N="${BASH_REMATCH[2]}"
+        REQ_P="${BASH_REMATCH[3]}"
+        REQ_IS_PRERELEASE=false
+        return 0
+    fi
+    err "Invalid release tag format: '$tag'"
+    return 3
+}
+
+# Select the anchor tag using rules A and B from the design spec.
+# Reads REQ_M, REQ_N, REQ_P, REQ_IS_PRERELEASE set by parse_release_tag.
+# Writes anchor_tag and anchor_kind to stdout as KEY=VALUE pairs.
+select_anchor() {
+    # Stub. Implemented in Task 2.
+    printf 'anchor_tag=\n'
+    printf 'anchor_kind=none\n'
+}
+
+main() {
+    local tag="${1:-}"
+    [ -n "$tag" ] || { err "release_tag argument required"; return 3; }
+    parse_release_tag "$tag" || return $?
+    select_anchor "$tag"
+}
+
+# ─── self-test harness ─────────────────────────────────────────────────────
+
+self_test() {
+    local pass=0 fail=0
+    assert_equal() {
+        local desc="$1" expected="$2" actual="$3"
+        if [ "$expected" = "$actual" ]; then
+            echo "PASS: $desc"
+            pass=$((pass + 1))
+        else
+            echo "FAIL: $desc"
+            echo "  expected: $expected"
+            echo "  actual:   $actual"
+            fail=$((fail + 1))
+        fi
+    }
+
+    # Case 1: no prior stable releases -> kind=none
+    lookup_releases() { :; }
+    local out
+    out=$(main "v9.2.0-alpha.260605")
+    assert_equal "case 1: no prior stable -> anchor_kind=none" \
+        "anchor_kind=none" \
+        "$(echo "$out" | grep '^anchor_kind=')"
+    assert_equal "case 1: no prior stable -> anchor_tag empty" \
+        "anchor_tag=" \
+        "$(echo "$out" | grep '^anchor_tag=')"
+
+    echo
+    echo "Results: $pass passed, $fail failed"
+    [ "$fail" -eq 0 ]
+}
+
+if [ "${1:-}" = "--self-test" ]; then
+    self_test
+    exit $?
+fi
+
+main "$@"

--- a/scripts/find-previous-release.sh
+++ b/scripts/find-previous-release.sh
@@ -85,6 +85,23 @@ select_anchor() {
         return 0
     fi
 
+    # Rule B: patches (P > 0 on a stable tag, no prerelease).
+    if [ "$is_prerelease" = "false" ] && [ "$p" -gt 0 ]; then
+        local target="v${m}.${n}.0"
+        local c
+        for c in "${candidates[@]}"; do
+            local c_tag="${c##* }"
+            if [ "$c_tag" = "$target" ]; then
+                printf 'anchor_tag=%s\n' "$target"
+                printf 'anchor_kind=stable\n'
+                return 0
+            fi
+        done
+        printf 'anchor_tag=\n'
+        printf 'anchor_kind=none\n'
+        return 0
+    fi
+
     # Rule A: pre-releases and v{M}.{N}.0 finals.
     # Filter to candidates strictly below the current M.N, then pick the
     # SemVer-highest (M', N', P') tuple.
@@ -211,6 +228,27 @@ self_test() {
     assert_equal "case 11: v9.3.0-alpha anchors against highest M.N stable v9.2.5" \
         "anchor_tag=v9.2.5" \
         "$(echo "$out" | grep '^anchor_tag=')"
+
+    # Case 6: patch v9.2.1 with v9.2.0 shipped -> v9.2.0
+    lookup_releases() { printf '%s\n' "v9.1.0" "v9.2.0"; }
+    out=$(main "v9.2.1")
+    assert_equal "case 6: patch v9.2.1 -> v9.2.0" \
+        "anchor_tag=v9.2.0" \
+        "$(echo "$out" | grep '^anchor_tag=')"
+
+    # Case 7: patch v9.2.5 with v9.2.0-v9.2.4 -> v9.2.0 (cumulative within patch series)
+    lookup_releases() { printf '%s\n' "v9.1.0" "v9.2.0" "v9.2.1" "v9.2.2" "v9.2.3" "v9.2.4"; }
+    out=$(main "v9.2.5")
+    assert_equal "case 7: patch v9.2.5 -> v9.2.0 (cumulative)" \
+        "anchor_tag=v9.2.0" \
+        "$(echo "$out" | grep '^anchor_tag=')"
+
+    # Case 8: patch with no v{M}.{N}.0 (defensive) -> kind=none
+    lookup_releases() { printf '%s\n' "v9.1.0"; }
+    out=$(main "v9.2.1")
+    assert_equal "case 8: patch with no v.0 -> anchor_kind=none" \
+        "anchor_kind=none" \
+        "$(echo "$out" | grep '^anchor_kind=')"
 
     echo
     echo "Results: $pass passed, $fail failed"

--- a/scripts/generate_release_notes.py
+++ b/scripts/generate_release_notes.py
@@ -12,8 +12,8 @@ current tip SHA so subsequent diffs have a baseline.
 
 Inputs:
   argv[1]: path to current dep-manifest.json (required)
-  argv[2]: path to previous dep-manifest.json (optional — pass an empty
-           string or missing path for an initial publish)
+  argv[2]: path to previous dep-manifest.json (optional). Pass an empty
+           string or omit for an initial publish.
   argv[3]: output Markdown path (defaults to release-notes-section.md)
 
 Environment:
@@ -67,8 +67,8 @@ def api(path: str) -> dict | list | None:
     except urllib.error.HTTPError as e:
         if e.code in (404, 422):
             return None
-        # Surface other errors but don't crash the whole publish — one dep's
-        # API failure shouldn't take down the release.
+        # Surface other errors but do not crash the whole publish. A single
+        # dep's API failure should not take down the release.
         print(f"::warning::HTTP {e.code} fetching {url}: {e.reason}", file=sys.stderr)
         return None
     except (urllib.error.URLError, TimeoutError) as e:
@@ -83,12 +83,12 @@ def short(sha: str) -> str:
 def render_initial_notes(curr: dict) -> str:
     n = len(curr.get("deps", {}))
     return (
-        "### Initial publish\n"
+        "### Initial release\n"
         "\n"
-        f"This is the first build with no prior release to diff against. The full "
-        f"dep state ({n} repos, branch + tip SHA each) is in the attached "
-        "`dep-manifest.json`. Subsequent releases will show the per-dep PR diff "
-        "against the previous build instead.\n"
+        f"No prior alpha release exists for comparison. The full set of "
+        f"dependencies ({n} repositories, each with branch and tip SHA) is "
+        "recorded in the attached `dep-manifest.json`. Future releases will "
+        "include a per-repository PR diff against the prior build.\n"
     )
 
 
@@ -101,8 +101,8 @@ def render_dep_changes(repo: str, prev_sha: str, curr_sha: str) -> list[str]:
         return [
             f"#### {repo} {header_range}",
             "",
-            f"*Compare range not resolvable (possibly a force-push on the branch). "
-            f"[See on GitHub](https://github.com/{repo}/compare/{prev_sha}...{curr_sha}).*",
+            f"_Commit range could not be resolved, possibly due to a force-push on the branch. "
+            f"[Compare on GitHub](https://github.com/{repo}/compare/{prev_sha}...{curr_sha})._",
             "",
         ]
 
@@ -111,7 +111,7 @@ def render_dep_changes(repo: str, prev_sha: str, curr_sha: str) -> list[str]:
         return [
             f"#### {repo} {header_range}",
             "",
-            "*No commits in range.*",
+            "_No commits in range._",
             "",
         ]
 
@@ -122,7 +122,7 @@ def render_dep_changes(repo: str, prev_sha: str, curr_sha: str) -> list[str]:
 
     for c in commits:
         if len(c.get("parents", [])) > 1:
-            # Skip merge commits — their content is reflected via the PR.
+            # Skip merge commits. Their content is reflected via the PR.
             continue
         sha = c["sha"]
         commit_prs = api(f"repos/{repo}/commits/{sha}/pulls") or []
@@ -140,7 +140,7 @@ def render_dep_changes(repo: str, prev_sha: str, curr_sha: str) -> list[str]:
                 "author": c["commit"]["author"]["name"],
             })
 
-    # Header line summarising what's in this section.
+    # Header line summarising the contents of this section.
     bits: list[str] = []
     if prs:
         s = "s" if len(prs) > 1 else ""
@@ -149,27 +149,27 @@ def render_dep_changes(repo: str, prev_sha: str, curr_sha: str) -> list[str]:
         s = "s" if len(direct) > 1 else ""
         bits.append(f"{len(direct)} direct commit{s}")
     if not bits:
-        # No non-merge commits, only merge commits. Should be rare.
+        # No non-merge commits; only merge commits. Should be rare.
         bits.append(f"{len(commits)} commits")
 
-    out = [f"#### {repo} {header_range} — {', '.join(bits)}", ""]
+    out = [f"#### {repo} {header_range}: {', '.join(bits)}", ""]
 
-    # Cap per-dep PR list to keep release bodies under GitHub's 125 KB limit.
+    # Cap per-repository entries to keep release bodies under GitHub's 125 KB limit.
     PR_CAP = 30
     for pr in prs[:PR_CAP]:
         author = (pr.get("user") or {}).get("login", "?")
         out.append(f"- [#{pr['number']}]({pr['html_url']}): {pr['title']} (@{author})")
     if len(prs) > PR_CAP:
-        out.append(f"- *…and {len(prs) - PR_CAP} more.*")
+        out.append(f"- _...and {len(prs) - PR_CAP} more._")
 
     if direct:
         if prs:
             out.append("")
-            out.append("*Direct commits (bypassing PR):*")
+            out.append("_Direct commits (not associated with a merged PR):_")
         for d in direct[:PR_CAP]:
             out.append(f"- {d['message']} ({d['author']}) `{short(d['sha'])}`")
         if len(direct) > PR_CAP:
-            out.append(f"- *…and {len(direct) - PR_CAP} more.*")
+            out.append(f"- _...and {len(direct) - PR_CAP} more._")
 
     out.append("")
     return out
@@ -191,12 +191,12 @@ def render_diff_notes(prev: dict, curr: dict) -> str:
     unchanged = sum(1 for r in prev_set & curr_set if prev_deps[r]["sha"] == curr_deps[r]["sha"])
     total = len(curr_set)
 
-    lines = ["### Dependency changes since last nightly", ""]
+    lines = ["### Dependency changes since previous release", ""]
 
     if not changed and not added and not removed:
-        lines.append("*No upstream changes since the previous build.*")
+        lines.append("_No upstream changes since the previous release._")
         lines.append("")
-        lines.append(f"*{total} of {total} deps unchanged.*")
+        lines.append(f"_{total} of {total} dependencies unchanged._")
         lines.append("")
         return "\n".join(lines)
 
@@ -207,7 +207,7 @@ def render_diff_notes(prev: dict, curr: dict) -> str:
         info = curr_deps[repo]
         lines.append(f"#### Newly included: {repo} `{short(info.get('sha', ''))}`")
         lines.append("")
-        lines.append("*(No prior version to compare against.)*")
+        lines.append("_No prior version exists for comparison._")
         lines.append("")
 
     if removed:
@@ -217,7 +217,7 @@ def render_diff_notes(prev: dict, curr: dict) -> str:
             lines.append(f"- {repo} (was at `{short(prev_deps[repo].get('sha', ''))}`)")
         lines.append("")
 
-    lines.append(f"*{unchanged} of {total} deps unchanged since last build.*")
+    lines.append(f"_{unchanged} of {total} dependencies unchanged since the previous release._")
     lines.append("")
     return "\n".join(lines)
 
@@ -239,7 +239,7 @@ def main() -> int:
             prev = json.load(f)
         body = render_diff_notes(prev, curr)
     else:
-        print("::notice::No previous manifest provided — emitting initial-publish baseline")
+        print("::notice::No previous manifest provided. Emitting initial-publish baseline.")
         body = render_initial_notes(curr)
 
     with open(out_path, "w", encoding="utf-8", newline="\n") as f:

--- a/scripts/generate_release_notes.py
+++ b/scripts/generate_release_notes.py
@@ -81,21 +81,15 @@ def short(sha: str) -> str:
 
 
 def render_initial_notes(curr: dict) -> str:
-    deps = curr.get("deps", {})
-    lines = [
-        "### Initial nightly-alpha publish",
-        "",
-        "This is the first build under this tag. Subsequent releases will "
-        "diff their dep tips against this baseline.",
-        "",
-        "| Repo | Branch | Tip |",
-        "|---|---|---|",
-    ]
-    for repo in sorted(deps):
-        info = deps[repo]
-        lines.append(f"| {repo} | {info.get('branch', '?')} | `{short(info.get('sha', ''))}` |")
-    lines.append("")
-    return "\n".join(lines)
+    n = len(curr.get("deps", {}))
+    return (
+        "### Initial publish\n"
+        "\n"
+        f"This is the first build with no prior release to diff against. The full "
+        f"dep state ({n} repos, branch + tip SHA each) is in the attached "
+        "`dep-manifest.json`. Subsequent releases will show the per-dep PR diff "
+        "against the previous build instead.\n"
+    )
 
 
 def render_dep_changes(repo: str, prev_sha: str, curr_sha: str) -> list[str]:

--- a/scripts/generate_release_notes.py
+++ b/scripts/generate_release_notes.py
@@ -175,7 +175,7 @@ def render_dep_changes(repo: str, prev_sha: str, curr_sha: str) -> list[str]:
     return out
 
 
-def render_diff_notes(prev: dict, curr: dict) -> str:
+def render_diff_notes(prev: dict, curr: dict, anchor_tag: str = "") -> str:
     prev_deps = prev.get("deps", {})
     curr_deps = curr.get("deps", {})
     prev_set = set(prev_deps)
@@ -191,7 +191,8 @@ def render_diff_notes(prev: dict, curr: dict) -> str:
     unchanged = sum(1 for r in prev_set & curr_set if prev_deps[r]["sha"] == curr_deps[r]["sha"])
     total = len(curr_set)
 
-    lines = ["### Dependency changes since previous release", ""]
+    heading = f"### Changes since {anchor_tag}" if anchor_tag else "### Dependency changes since previous release"
+    lines = [heading, ""]
 
     if not changed and not added and not removed:
         lines.append("_No upstream changes since the previous release._")
@@ -224,12 +225,16 @@ def render_diff_notes(prev: dict, curr: dict) -> str:
 
 def main() -> int:
     if len(sys.argv) < 2:
-        print("usage: generate_release_notes.py <current.json> [<previous.json>] [<out.md>]", file=sys.stderr)
+        print(
+            "usage: generate_release_notes.py <current.json> [<previous.json>] [<out.md>] [<anchor_tag>]",
+            file=sys.stderr,
+        )
         return 2
 
     curr_path = sys.argv[1]
     prev_path = sys.argv[2] if len(sys.argv) > 2 else ""
     out_path = sys.argv[3] if len(sys.argv) > 3 else "release-notes-section.md"
+    anchor_tag = sys.argv[4] if len(sys.argv) > 4 else ""
 
     with open(curr_path) as f:
         curr = json.load(f)
@@ -237,7 +242,7 @@ def main() -> int:
     if prev_path and os.path.isfile(prev_path):
         with open(prev_path) as f:
             prev = json.load(f)
-        body = render_diff_notes(prev, curr)
+        body = render_diff_notes(prev, curr, anchor_tag)
     else:
         print("::notice::No previous manifest provided. Emitting initial-publish baseline.")
         body = render_initial_notes(curr)

--- a/scripts/generate_release_notes.py
+++ b/scripts/generate_release_notes.py
@@ -1,0 +1,259 @@
+#!/usr/bin/env python3
+"""
+Generate Markdown release notes for the BHoM nightly-alpha release.
+
+Diffs the current build's per-dep manifest against the previous release's
+manifest and renders, per changed dep:
+  - PRs merged in the range (linked, with author handle)
+  - Direct commits not associated with any PR (fallback section)
+
+For an initial publish (no previous manifest), lists every dep with its
+current tip SHA so subsequent diffs have a baseline.
+
+Inputs:
+  argv[1]: path to current dep-manifest.json (required)
+  argv[2]: path to previous dep-manifest.json (optional — pass an empty
+           string or missing path for an initial publish)
+  argv[3]: output Markdown path (defaults to release-notes-section.md)
+
+Environment:
+  GH_TOKEN: a token with read access to every dep repo's commits/PRs.
+            Workflow github.token is enough for public BHoM repos; the
+            BHoM App token is needed when extended to private BHE deps.
+
+Manifest schema (version 1):
+  {
+    "version":      1,
+    "built_at":     "ISO8601",
+    "release_type": "alpha"|"beta",
+    "main_branch":  "develop",
+    "deps": {
+      "<owner>/<repo>": { "branch": "develop", "sha": "<40-char>" },
+      ...
+    }
+  }
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+
+
+GH_TOKEN = os.environ.get("GH_TOKEN", "")
+if not GH_TOKEN:
+    print("::error::GH_TOKEN env var is required", file=sys.stderr)
+    sys.exit(1)
+
+
+def api(path: str) -> dict | list | None:
+    """Call GitHub REST API. Returns parsed JSON, or None on 4xx not-found."""
+    url = f"https://api.github.com/{path.lstrip('/')}"
+    req = urllib.request.Request(
+        url,
+        headers={
+            "Authorization": f"Bearer {GH_TOKEN}",
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+            "User-Agent": "bhom-installer-release-notes",
+        },
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=20) as r:
+            return json.loads(r.read())
+    except urllib.error.HTTPError as e:
+        if e.code in (404, 422):
+            return None
+        # Surface other errors but don't crash the whole publish — one dep's
+        # API failure shouldn't take down the release.
+        print(f"::warning::HTTP {e.code} fetching {url}: {e.reason}", file=sys.stderr)
+        return None
+    except (urllib.error.URLError, TimeoutError) as e:
+        print(f"::warning::Network error fetching {url}: {e}", file=sys.stderr)
+        return None
+
+
+def short(sha: str) -> str:
+    return sha[:7] if sha else ""
+
+
+def render_initial_notes(curr: dict) -> str:
+    deps = curr.get("deps", {})
+    lines = [
+        "### Initial nightly-alpha publish",
+        "",
+        "This is the first build under this tag. Subsequent releases will "
+        "diff their dep tips against this baseline.",
+        "",
+        "| Repo | Branch | Tip |",
+        "|---|---|---|",
+    ]
+    for repo in sorted(deps):
+        info = deps[repo]
+        lines.append(f"| {repo} | {info.get('branch', '?')} | `{short(info.get('sha', ''))}` |")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def render_dep_changes(repo: str, prev_sha: str, curr_sha: str) -> list[str]:
+    """Render the section for one changed dep."""
+    cmp_data = api(f"repos/{repo}/compare/{prev_sha}...{curr_sha}")
+    header_range = f"`{short(prev_sha)}...{short(curr_sha)}`"
+
+    if cmp_data is None:
+        return [
+            f"#### {repo} {header_range}",
+            "",
+            f"*Compare range not resolvable (possibly a force-push on the branch). "
+            f"[See on GitHub](https://github.com/{repo}/compare/{prev_sha}...{curr_sha}).*",
+            "",
+        ]
+
+    commits = cmp_data.get("commits", [])
+    if not commits:
+        return [
+            f"#### {repo} {header_range}",
+            "",
+            "*No commits in range.*",
+            "",
+        ]
+
+    # Collect unique PRs and any direct (non-merge, non-PR) commits.
+    seen_pr_numbers: set[int] = set()
+    prs: list[dict] = []
+    direct: list[dict] = []
+
+    for c in commits:
+        if len(c.get("parents", [])) > 1:
+            # Skip merge commits — their content is reflected via the PR.
+            continue
+        sha = c["sha"]
+        commit_prs = api(f"repos/{repo}/commits/{sha}/pulls") or []
+        merged_prs = [p for p in commit_prs if p.get("merged_at")]
+
+        if merged_prs:
+            for pr in merged_prs:
+                if pr["number"] not in seen_pr_numbers:
+                    seen_pr_numbers.add(pr["number"])
+                    prs.append(pr)
+        else:
+            direct.append({
+                "sha": sha,
+                "message": c["commit"]["message"].split("\n", 1)[0],
+                "author": c["commit"]["author"]["name"],
+            })
+
+    # Header line summarising what's in this section.
+    bits: list[str] = []
+    if prs:
+        s = "s" if len(prs) > 1 else ""
+        bits.append(f"{len(prs)} PR{s} merged")
+    if direct:
+        s = "s" if len(direct) > 1 else ""
+        bits.append(f"{len(direct)} direct commit{s}")
+    if not bits:
+        # No non-merge commits, only merge commits. Should be rare.
+        bits.append(f"{len(commits)} commits")
+
+    out = [f"#### {repo} {header_range} — {', '.join(bits)}", ""]
+
+    # Cap per-dep PR list to keep release bodies under GitHub's 125 KB limit.
+    PR_CAP = 30
+    for pr in prs[:PR_CAP]:
+        author = (pr.get("user") or {}).get("login", "?")
+        out.append(f"- [#{pr['number']}]({pr['html_url']}): {pr['title']} (@{author})")
+    if len(prs) > PR_CAP:
+        out.append(f"- *…and {len(prs) - PR_CAP} more.*")
+
+    if direct:
+        if prs:
+            out.append("")
+            out.append("*Direct commits (bypassing PR):*")
+        for d in direct[:PR_CAP]:
+            out.append(f"- {d['message']} ({d['author']}) `{short(d['sha'])}`")
+        if len(direct) > PR_CAP:
+            out.append(f"- *…and {len(direct) - PR_CAP} more.*")
+
+    out.append("")
+    return out
+
+
+def render_diff_notes(prev: dict, curr: dict) -> str:
+    prev_deps = prev.get("deps", {})
+    curr_deps = curr.get("deps", {})
+    prev_set = set(prev_deps)
+    curr_set = set(curr_deps)
+
+    changed = [
+        (r, prev_deps[r]["sha"], curr_deps[r]["sha"])
+        for r in sorted(prev_set & curr_set)
+        if prev_deps[r]["sha"] != curr_deps[r]["sha"]
+    ]
+    added = sorted(curr_set - prev_set)
+    removed = sorted(prev_set - curr_set)
+    unchanged = sum(1 for r in prev_set & curr_set if prev_deps[r]["sha"] == curr_deps[r]["sha"])
+    total = len(curr_set)
+
+    lines = ["### Dependency changes since last nightly", ""]
+
+    if not changed and not added and not removed:
+        lines.append("*No upstream changes since the previous build.*")
+        lines.append("")
+        lines.append(f"*{total} of {total} deps unchanged.*")
+        lines.append("")
+        return "\n".join(lines)
+
+    for repo, p_sha, c_sha in changed:
+        lines.extend(render_dep_changes(repo, p_sha, c_sha))
+
+    for repo in added:
+        info = curr_deps[repo]
+        lines.append(f"#### Newly included: {repo} `{short(info.get('sha', ''))}`")
+        lines.append("")
+        lines.append("*(No prior version to compare against.)*")
+        lines.append("")
+
+    if removed:
+        lines.append("### Removed from build")
+        lines.append("")
+        for repo in removed:
+            lines.append(f"- {repo} (was at `{short(prev_deps[repo].get('sha', ''))}`)")
+        lines.append("")
+
+    lines.append(f"*{unchanged} of {total} deps unchanged since last build.*")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def main() -> int:
+    if len(sys.argv) < 2:
+        print("usage: generate_release_notes.py <current.json> [<previous.json>] [<out.md>]", file=sys.stderr)
+        return 2
+
+    curr_path = sys.argv[1]
+    prev_path = sys.argv[2] if len(sys.argv) > 2 else ""
+    out_path = sys.argv[3] if len(sys.argv) > 3 else "release-notes-section.md"
+
+    with open(curr_path) as f:
+        curr = json.load(f)
+
+    if prev_path and os.path.isfile(prev_path):
+        with open(prev_path) as f:
+            prev = json.load(f)
+        body = render_diff_notes(prev, curr)
+    else:
+        print("::notice::No previous manifest provided — emitting initial-publish baseline")
+        body = render_initial_notes(curr)
+
+    with open(out_path, "w", encoding="utf-8", newline="\n") as f:
+        f.write(body)
+
+    print(f"::notice::Wrote {out_path} ({len(body)} chars)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/notify-on-failure.sh
+++ b/scripts/notify-on-failure.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Open a GitHub Issue for a failed scheduled nightly build, or comment on
+# an existing one if a same-day failure already produced one.
+#
+# Two layers of signal:
+#   1. A workflow-page-visible '::error::' annotation. This is the lower
+#      bound, visible regardless of whether the repo has Issues enabled.
+#   2. A tracking Issue, created or updated. Skipped if Issues are
+#      disabled on the calling repo (the annotation above remains the
+#      failure marker in that case).
+#
+# Required environment:
+#   GITHUB_SERVER_URL    Provided by GitHub Actions.
+#   GITHUB_REPOSITORY    Provided by GitHub Actions.
+#   GITHUB_RUN_ID        Provided by GitHub Actions.
+#   GITHUB_SHA           Provided by GitHub Actions.
+#   GH_TOKEN             Token with 'issues: write' on the repo.
+#   BUILD_RESULT         Result of the 'build' job ('success', 'failure', etc).
+#   TEST_RESULT          Result of the 'install-test' matrix.
+set -eu
+
+today=$(date -u +%Y-%m-%d)
+title="[CI] Nightly alpha build failed ($today)"
+run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+
+# Workflow-page annotation: lower bound, fires regardless of repo config.
+echo "::error title=Nightly alpha build failed::See $run_url"
+
+# Skip tracking-issue creation if the repo has Issues disabled. This case
+# surfaced on the sandbox repo when notify-on-failure was first smoke-tested:
+# gh issue create errors with 'repository has disabled issues'. The
+# annotation above remains the failure signal.
+has_issues=$(gh api "repos/$GITHUB_REPOSITORY" --jq '.has_issues // false')
+if [ "$has_issues" != "true" ]; then
+    echo "::notice::Issues are disabled on $GITHUB_REPOSITORY. Skipping tracking-issue creation; the workflow annotation above remains the failure marker."
+    exit 0
+fi
+
+body=$(cat <<EOF
+The scheduled nightly alpha build failed.
+
+- **Run:** ${run_url}
+- **Commit:** \`${GITHUB_SHA}\`
+- **build job:** \`${BUILD_RESULT}\`
+- **install-test matrix:** \`${TEST_RESULT}\`
+
+See the run log for details. This issue auto-opens when a scheduled
+run fails; close it once the underlying issue is resolved.
+EOF
+)
+
+# Avoid spamming: if an open issue already exists with this exact title
+# (another failure already happened today), comment on it instead of
+# opening a duplicate.
+existing=$(gh issue list \
+    --repo "$GITHUB_REPOSITORY" \
+    --search "in:title \"$title\"" \
+    --state open \
+    --json number --jq '.[0].number // empty')
+
+if [ -n "$existing" ]; then
+    gh issue comment "$existing" --repo "$GITHUB_REPOSITORY" --body "$body"
+    echo "Commented on existing issue #$existing"
+else
+    gh issue create \
+        --repo "$GITHUB_REPOSITORY" \
+        --title "$title" \
+        --body "$body"
+fi

--- a/scripts/notify-on-failure.sh
+++ b/scripts/notify-on-failure.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
-# Open a GitHub Issue for a failed scheduled nightly build, or comment on
-# an existing one if a same-day failure already produced one.
+# Open a GitHub Issue for a failed non-interactive build (scheduled nightly
+# or tag-push release), or comment on an existing one if a same-day failure
+# already produced one with the same title.
 #
 # Two layers of signal:
 #   1. A workflow-page-visible '::error::' annotation. This is the lower
@@ -14,17 +15,31 @@
 #   GITHUB_REPOSITORY    Provided by GitHub Actions.
 #   GITHUB_RUN_ID        Provided by GitHub Actions.
 #   GITHUB_SHA           Provided by GitHub Actions.
+#   GITHUB_EVENT_NAME    Provided by GitHub Actions. Used to flavour the
+#                        issue title.
+#   GITHUB_REF_NAME      Provided by GitHub Actions. Used in the title for
+#                        tag-push events.
 #   GH_TOKEN             Token with 'issues: write' on the repo.
 #   BUILD_RESULT         Result of the 'build' job ('success', 'failure', etc).
 #   TEST_RESULT          Result of the 'install-test' matrix.
 set -eu
 
 today=$(date -u +%Y-%m-%d)
-title="[CI] Nightly alpha build failed ($today)"
 run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
 
+case "$GITHUB_EVENT_NAME" in
+    push)
+        title="[CI] Release build failed for tag ${GITHUB_REF_NAME} ($today)"
+        annotation="Release build failed for tag ${GITHUB_REF_NAME}"
+        ;;
+    *)
+        title="[CI] Nightly alpha build failed ($today)"
+        annotation="Nightly alpha build failed"
+        ;;
+esac
+
 # Workflow-page annotation: lower bound, fires regardless of repo config.
-echo "::error title=Nightly alpha build failed::See $run_url"
+echo "::error title=${annotation}::See $run_url"
 
 # Skip tracking-issue creation if the repo has Issues disabled. This case
 # surfaced on the sandbox repo when notify-on-failure was first smoke-tested:
@@ -36,16 +51,25 @@ if [ "$has_issues" != "true" ]; then
     exit 0
 fi
 
+case "$GITHUB_EVENT_NAME" in
+    push)
+        intro="The release build for tag \`${GITHUB_REF_NAME}\` failed. A coordinator pushed this tag expecting a finalised release; the workflow did not complete."
+        ;;
+    *)
+        intro="The scheduled nightly alpha build failed."
+        ;;
+esac
+
 body=$(cat <<EOF
-The scheduled nightly alpha build failed.
+${intro}
 
 - **Run:** ${run_url}
 - **Commit:** \`${GITHUB_SHA}\`
 - **build job:** \`${BUILD_RESULT}\`
 - **install-test matrix:** \`${TEST_RESULT}\`
 
-See the run log for details. This issue auto-opens when a scheduled
-run fails; close it once the underlying issue is resolved.
+See the run log for details. This issue auto-opens when a non-interactive
+build fails; close it once the underlying problem is resolved.
 EOF
 )
 

--- a/scripts/resolve-release-tag.sh
+++ b/scripts/resolve-release-tag.sh
@@ -1,0 +1,505 @@
+#!/usr/bin/env bash
+# Resolve the release tag and downstream parameters for build-installer.yml.
+#
+# Reads workflow context from environment variables, computes the tag for
+# the current build, runs the five conflict-prevention rules, and writes
+# KEY=VALUE pairs to stdout (intended to be appended to $GITHUB_OUTPUT).
+#
+# Inputs (env):
+#   GITHUB_EVENT_NAME    'schedule' | 'workflow_dispatch' | 'push'
+#   GITHUB_REF_NAME      For 'push': the pushed tag (e.g. 'v9.2.0').
+#   GITHUB_REPOSITORY    'owner/repo' for the gh API calls.
+#   INPUT_RELEASE_TYPE   'alpha' | 'beta' on workflow_dispatch; empty otherwise.
+#   INPUT_SOURCE_BRANCH  Branch to build from on alpha dispatch; default 'develop'.
+#   GH_TOKEN             For gh api calls. Workflow's github.token is sufficient.
+#
+# Outputs (stdout):
+#   release_type=<alpha|beta>
+#   source_branch=<branch>
+#   prerelease=<true|false>
+#   make_latest=<true|false>
+#   release_tag=<the computed tag>
+#
+# Exit codes:
+#   0  success
+#   2  conflict-prevention rule violation (message on stderr)
+#   3  internal error / missing inputs
+
+set -euo pipefail
+
+# ─── tag-lookup IO (overridable in --self-test) ─────────────────────────────
+
+# Print existing tag names on the current repo, one per line. Override in
+# tests by redefining this function before calling resolve_main().
+lookup_tags() {
+    gh api "repos/${GITHUB_REPOSITORY}/git/refs/tags" --paginate \
+        --jq '.[].ref | sub("^refs/tags/"; "")'
+}
+
+# Print existing published-release tag names, one per line. Override in tests.
+# Distinct from lookup_tags because a tag can exist without a release.
+lookup_releases() {
+    gh api "repos/${GITHUB_REPOSITORY}/releases" --paginate \
+        --jq '.[].tag_name'
+}
+
+# ─── core logic (filled in by subsequent tasks) ─────────────────────────────
+
+# Print "MAJOR MINOR" extracted from the wixproj file. Errors to stderr on
+# missing/invalid input.
+read_wixproj_version() {
+    local file="$1"
+    [ -f "$file" ] || { err "wixproj file not found: $file"; return 3; }
+
+    local major minor
+    major=$(grep -oE '<MajorVersion[^>]*>[0-9]+</MajorVersion>' "$file" \
+            | grep -oE '>[0-9]+<' | tr -d '><' | head -n1)
+    minor=$(grep -oE '<MinorVersion[^>]*>[0-9]+</MinorVersion>' "$file" \
+            | grep -oE '>[0-9]+<' | tr -d '><' | head -n1)
+
+    [ -n "$major" ] || { err "MajorVersion not found in $file"; return 3; }
+    [ -n "$minor" ] || { err "MinorVersion not found in $file"; return 3; }
+    printf '%s %s\n' "$major" "$minor"
+}
+
+# Compute the alpha tag for a given Major, Minor, and date.
+# Looks at existing tags via lookup_tags() to determine the intra-day counter.
+compute_alpha_tag() {
+    local m="$1" n="$2" date="$3"
+    local prefix="v${m}.${n}.0-alpha.${date}"
+    local existing
+    existing=$(lookup_tags | grep -E "^${prefix}(\.[0-9]+)?\$" || true)
+
+    if [ -z "$existing" ]; then
+        printf '%s\n' "$prefix"
+        return 0
+    fi
+
+    # Highest counter found (0 if only the bare 'prefix' exists with no .N).
+    local max=1
+    while IFS= read -r tag; do
+        [ -z "$tag" ] && continue
+        if [ "$tag" = "$prefix" ]; then
+            continue   # counts as '.1' implicitly
+        fi
+        local suffix="${tag#${prefix}.}"
+        if [[ "$suffix" =~ ^[0-9]+$ ]] && [ "$suffix" -gt "$max" ]; then
+            max="$suffix"
+        fi
+    done <<< "$existing"
+
+    printf '%s.%d\n' "$prefix" "$((max + 1))"
+}
+
+# Compute the beta-pre-release tag for a given Major, Minor.
+# Tag format: vM.N.0-beta.counter where counter is monotonic per (M,N,0).
+compute_beta_tag() {
+    local m="$1" n="$2"
+    local prefix="v${m}.${n}.0-beta"
+    local existing
+    existing=$(lookup_tags | grep -E "^${prefix}\\.[0-9]+\$" || true)
+
+    local max=0
+    while IFS= read -r tag; do
+        [ -z "$tag" ] && continue
+        local suffix="${tag#${prefix}.}"
+        if [[ "$suffix" =~ ^[0-9]+$ ]] && [ "$suffix" -gt "$max" ]; then
+            max="$suffix"
+        fi
+    done <<< "$existing"
+
+    printf '%s.%d\n' "$prefix" "$((max + 1))"
+}
+
+# Validate that a pushed tag is of form v{M}.{N}.{P} (no pre-release suffix)
+# and that its M.N matches the wixproj. Exits non-zero with an ::error:: on
+# failure; prints the tag on success.
+validate_release_tag() {
+    local tag="$1" wix_m="$2" wix_n="$3"
+
+    if ! [[ "$tag" =~ ^v([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+        err "Pushed tag '$tag' is not of form v{major}.{minor}.{patch} with no pre-release suffix. Final release tags only — push pre-release builds via workflow_dispatch instead."
+        return 2
+    fi
+
+    local tag_m="${BASH_REMATCH[1]}" tag_n="${BASH_REMATCH[2]}"
+    if [ "$tag_m" != "$wix_m" ] || [ "$tag_n" != "$wix_n" ]; then
+        err "Pushed tag '$tag' (${tag_m}.${tag_n}) does not match BHoM_Installer.wixproj MajorVersion.MinorVersion (${wix_m}.${wix_n}). Either bump the wixproj before pushing, or push a v${wix_m}.${wix_n}.x tag."
+        return 2
+    fi
+
+    printf '%s\n' "$tag"
+}
+
+# Conflict rule 3: a pre-release build is being attempted while a release
+# for v{wix_m}.{wix_n}.0 has already shipped. Bump wixproj or quit.
+assert_no_shipped_release_for() {
+    local wix_m="$1" wix_n="$2"
+    local target="v${wix_m}.${wix_n}.0"
+    if lookup_releases | grep -Fxq "$target"; then
+        err "Wixproj MajorVersion.MinorVersion (${wix_m}.${wix_n}) maps to ${target} which has already been released. Bump MajorVersion or MinorVersion in BHoM_Installer.wixproj before publishing further pre-releases."
+        return 2
+    fi
+}
+
+# Conflict rule 4: the pushed tag has already been published as a release.
+# softprops/action-gh-release would fail later; surface it now.
+assert_release_not_already_published() {
+    local tag="$1"
+    if lookup_releases | grep -Fxq "$tag"; then
+        err "${tag} has already been released. To re-release, delete the existing release in the GitHub UI first; to ship a follow-up, push a new tag (e.g. the next patch)."
+        return 2
+    fi
+}
+
+# Top-level orchestrator. Reads workflow context from env, computes the
+# tag and outputs, runs conflict-prevention rules. Writes KEY=VALUE pairs
+# to stdout (intended to be appended to $GITHUB_OUTPUT).
+resolve_main() {
+    local event="${GITHUB_EVENT_NAME:-}"
+    local ref="${GITHUB_REF_NAME:-}"
+    local in_type="${INPUT_RELEASE_TYPE:-}"
+    local in_branch="${INPUT_SOURCE_BRANCH:-}"
+
+    local wixproj="${WIXPROJ_PATH:-BHoM_Installer/BHoM_Installer.wixproj}"
+    local mn; mn=$(read_wixproj_version "$wixproj") || return 3
+    local wix_m wix_n; read -r wix_m wix_n <<< "$mn"
+
+    local today="${TODAY_OVERRIDE:-$(date -u +%y%m%d)}"
+
+    local release_type source_branch prerelease make_latest release_tag msi_patch_version=""
+
+    case "$event" in
+        schedule)
+            release_type=alpha
+            source_branch=develop
+            prerelease=true
+            make_latest=false
+            assert_no_shipped_release_for "$wix_m" "$wix_n" || return 2
+            release_tag=$(compute_alpha_tag "$wix_m" "$wix_n" "$today")
+            # msi_patch_version="" — Build-Installer.ps1 defaults to yyMMdd.
+            ;;
+
+        workflow_dispatch)
+            release_type="${in_type:-alpha}"
+            case "$release_type" in
+                alpha)
+                    source_branch="${in_branch:-develop}"
+                    assert_no_shipped_release_for "$wix_m" "$wix_n" || return 2
+                    release_tag=$(compute_alpha_tag "$wix_m" "$wix_n" "$today")
+                    # msi_patch_version="" — Build-Installer.ps1 defaults to yyMMdd.
+                    ;;
+                beta)
+                    # Beta dispatch always builds from develop regardless of input.
+                    source_branch=develop
+                    assert_no_shipped_release_for "$wix_m" "$wix_n" || return 2
+                    release_tag=$(compute_beta_tag "$wix_m" "$wix_n")
+                    # MSI PatchVersion = the beta counter (e.g. v9.2.0-beta.3 -> 3).
+                    msi_patch_version="${release_tag##*-beta.}"
+                    ;;
+                *)
+                    err "Unknown release_type '$release_type' (expected alpha or beta)"
+                    return 3
+                    ;;
+            esac
+            prerelease=true
+            make_latest=false
+            ;;
+
+        push)
+            release_type=beta
+            source_branch=main
+            prerelease=false
+            make_latest=true
+            release_tag=$(validate_release_tag "$ref" "$wix_m" "$wix_n") || return 2
+            assert_release_not_already_published "$release_tag" || return 2
+            # MSI PatchVersion = the patch component of the pushed tag.
+            if [[ "$release_tag" =~ ^v[0-9]+\.[0-9]+\.([0-9]+)$ ]]; then
+                msi_patch_version="${BASH_REMATCH[1]}"
+            else
+                msi_patch_version=0
+            fi
+            ;;
+
+        *)
+            err "Unsupported event '$event'"
+            return 3
+            ;;
+    esac
+
+    printf 'release_type=%s\n'      "$release_type"
+    printf 'source_branch=%s\n'     "$source_branch"
+    printf 'prerelease=%s\n'        "$prerelease"
+    printf 'make_latest=%s\n'       "$make_latest"
+    printf 'release_tag=%s\n'       "$release_tag"
+    printf 'msi_patch_version=%s\n' "$msi_patch_version"
+}
+
+err() { printf '::error::%s\n' "$*" >&2; }
+
+# ─── self-test harness ─────────────────────────────────────────────────────
+
+self_test() {
+    local pass=0 fail=0
+    assert_equal() {
+        local desc="$1" expected="$2" actual="$3"
+        if [ "$expected" = "$actual" ]; then
+            echo "PASS: $desc"
+            pass=$((pass + 1))
+        else
+            echo "FAIL: $desc"
+            echo "  expected: $expected"
+            echo "  actual:   $actual"
+            fail=$((fail + 1))
+        fi
+    }
+
+    # ── read_wixproj_version ──
+    local tmp; tmp=$(mktemp)
+
+    cat > "$tmp" <<'EOF'
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+  <PropertyGroup>
+    <MajorVersion Condition=" '$(MajorVersion)' == '' ">9</MajorVersion>
+    <MinorVersion Condition=" '$(MinorVersion)' == '' ">2</MinorVersion>
+  </PropertyGroup>
+</Project>
+EOF
+    assert_equal "wixproj happy path" "9 2" "$(read_wixproj_version "$tmp")"
+
+    cat > "$tmp" <<'EOF'
+<Project>
+  <PropertyGroup>
+    <MajorVersion>10</MajorVersion>
+    <MinorVersion>14</MinorVersion>
+  </PropertyGroup>
+</Project>
+EOF
+    assert_equal "wixproj no-condition double-digit" "10 14" "$(read_wixproj_version "$tmp")"
+
+    cat > "$tmp" <<'EOF'
+<Project><PropertyGroup><MajorVersion>9</MajorVersion></PropertyGroup></Project>
+EOF
+    local out; out=$(read_wixproj_version "$tmp" 2>&1 || true)
+    case "$out" in
+        *"MinorVersion not found"*) assert_equal "wixproj missing minor errors" "ok" "ok" ;;
+        *) assert_equal "wixproj missing minor errors" "ok" "got: $out" ;;
+    esac
+
+    rm -f "$tmp"
+
+    # ── compute_alpha_tag ──
+    # Tag format: vM.N.0-alpha.YYMMDD[.counter]
+    # The counter is absent on the first build of the day, '.2' on the second, etc.
+
+    lookup_tags() { :; }   # no existing tags
+    assert_equal "alpha first build of day" \
+        "v9.2.0-alpha.260605" "$(compute_alpha_tag 9 2 260605)"
+
+    lookup_tags() { printf '%s\n' "v9.2.0-alpha.260605"; }
+    assert_equal "alpha second build of day" \
+        "v9.2.0-alpha.260605.2" "$(compute_alpha_tag 9 2 260605)"
+
+    lookup_tags() { printf '%s\n' "v9.2.0-alpha.260605" "v9.2.0-alpha.260605.2" "v9.2.0-alpha.260605.3"; }
+    assert_equal "alpha fourth build of day" \
+        "v9.2.0-alpha.260605.4" "$(compute_alpha_tag 9 2 260605)"
+
+    # Tags from a different day or version do not influence the counter.
+    lookup_tags() { printf '%s\n' "v9.2.0-alpha.260604" "v9.2.0-alpha.260604.2" "v9.3.0-alpha.260605"; }
+    assert_equal "alpha ignores other-day other-version tags" \
+        "v9.2.0-alpha.260605" "$(compute_alpha_tag 9 2 260605)"
+
+    # Restore the real lookup_tags for any later tests.
+    unset -f lookup_tags
+    lookup_tags() {
+        gh api "repos/${GITHUB_REPOSITORY}/git/refs/tags" --paginate \
+            --jq '.[].ref | sub("^refs/tags/"; "")'
+    }
+
+    # ── compute_beta_tag ──
+    # Tag format: vM.N.0-beta.counter, counter starts at 1.
+
+    lookup_tags() { :; }
+    assert_equal "beta first" "v9.2.0-beta.1" "$(compute_beta_tag 9 2)"
+
+    lookup_tags() { printf '%s\n' "v9.2.0-beta.1"; }
+    assert_equal "beta second" "v9.2.0-beta.2" "$(compute_beta_tag 9 2)"
+
+    lookup_tags() { printf '%s\n' "v9.2.0-beta.1" "v9.2.0-beta.2" "v9.2.0-beta.5"; }
+    assert_equal "beta after gap" "v9.2.0-beta.6" "$(compute_beta_tag 9 2)"
+
+    # Alpha tags do not influence the beta counter.
+    lookup_tags() { printf '%s\n' "v9.2.0-alpha.260605" "v9.2.0-alpha.260605.2"; }
+    assert_equal "beta ignores alpha tags" "v9.2.0-beta.1" "$(compute_beta_tag 9 2)"
+
+    unset -f lookup_tags
+    lookup_tags() {
+        gh api "repos/${GITHUB_REPOSITORY}/git/refs/tags" --paginate \
+            --jq '.[].ref | sub("^refs/tags/"; "")'
+    }
+
+    # ── validate_release_tag ──
+    # Pushed tag must be v{M}.{N}.{P} (no pre-release suffix), where {M}.{N}
+    # matches wixproj. Errors otherwise.
+
+    assert_equal "release tag happy v9.2.0" "ok" \
+        "$(validate_release_tag "v9.2.0" 9 2 >/dev/null 2>&1 && echo ok || echo fail)"
+
+    assert_equal "release tag happy v9.2.5 patch" "ok" \
+        "$(validate_release_tag "v9.2.5" 9 2 >/dev/null 2>&1 && echo ok || echo fail)"
+
+    assert_equal "release tag rejects pre-release suffix" "fail" \
+        "$(validate_release_tag "v9.2.0-rc.1" 9 2 >/dev/null 2>&1 && echo ok || echo fail)"
+
+    assert_equal "release tag rejects M.N mismatch" "fail" \
+        "$(validate_release_tag "v9.3.0" 9 2 >/dev/null 2>&1 && echo ok || echo fail)"
+
+    assert_equal "release tag rejects malformed" "fail" \
+        "$(validate_release_tag "v9.2" 9 2 >/dev/null 2>&1 && echo ok || echo fail)"
+
+    # ── assert_no_shipped_release_for + assert_release_not_already_published ──
+
+    lookup_releases() { :; }
+    assert_equal "no released v9.2.0 - pre-releases ok" "ok" \
+        "$(assert_no_shipped_release_for 9 2 >/dev/null 2>&1 && echo ok || echo fail)"
+
+    lookup_releases() { printf '%s\n' "v9.2.0"; }
+    assert_equal "v9.2.0 already shipped blocks pre-release" "fail" \
+        "$(assert_no_shipped_release_for 9 2 >/dev/null 2>&1 && echo ok || echo fail)"
+
+    lookup_releases() { printf '%s\n' "v9.1.0" "v9.2.0-alpha.260601"; }
+    assert_equal "v9.2.0-alpha published does not block more alphas" "ok" \
+        "$(assert_no_shipped_release_for 9 2 >/dev/null 2>&1 && echo ok || echo fail)"
+
+    lookup_releases() { :; }
+    assert_equal "rule 4: tag not yet released ok" "ok" \
+        "$(assert_release_not_already_published "v9.2.0" >/dev/null 2>&1 && echo ok || echo fail)"
+
+    lookup_releases() { printf '%s\n' "v9.2.0"; }
+    assert_equal "rule 4: tag already released blocks push" "fail" \
+        "$(assert_release_not_already_published "v9.2.0" >/dev/null 2>&1 && echo ok || echo fail)"
+
+    unset -f lookup_releases
+    lookup_releases() {
+        gh api "repos/${GITHUB_REPOSITORY}/releases" --paginate \
+            --jq '.[].tag_name'
+    }
+
+    # ── resolve_main integration ──
+    # Drive resolve_main via env vars and capture stdout. Override
+    # lookup_tags/lookup_releases per case.
+
+    local wixproj_tmp; wixproj_tmp=$(mktemp)
+    cat > "$wixproj_tmp" <<'EOF'
+<Project><PropertyGroup>
+  <MajorVersion>9</MajorVersion>
+  <MinorVersion>2</MinorVersion>
+</PropertyGroup></Project>
+EOF
+    export WIXPROJ_PATH="$wixproj_tmp"
+    export TODAY_OVERRIDE="260605"
+
+    # Schedule -> alpha pre-release for today.
+    export GITHUB_EVENT_NAME=schedule GITHUB_REF_NAME=develop \
+        INPUT_RELEASE_TYPE="" INPUT_SOURCE_BRANCH=""
+    local out; out=$(lookup_tags()    { :; }; \
+                     lookup_releases(){ :; }; \
+                     resolve_main 2>/dev/null)
+    assert_equal "schedule -> release_type=alpha"     "alpha"                "$(echo "$out" | grep '^release_type='  | cut -d= -f2)"
+    assert_equal "schedule -> source_branch=develop"  "develop"              "$(echo "$out" | grep '^source_branch=' | cut -d= -f2)"
+    assert_equal "schedule -> prerelease=true"        "true"                 "$(echo "$out" | grep '^prerelease='    | cut -d= -f2)"
+    assert_equal "schedule -> make_latest=false"      "false"                "$(echo "$out" | grep '^make_latest='   | cut -d= -f2)"
+    assert_equal "schedule -> release_tag computed"   "v9.2.0-alpha.260605"  "$(echo "$out" | grep '^release_tag='   | cut -d= -f2)"
+
+    # workflow_dispatch beta -> beta-pre-release.
+    export GITHUB_EVENT_NAME=workflow_dispatch GITHUB_REF_NAME=develop \
+        INPUT_RELEASE_TYPE=beta INPUT_SOURCE_BRANCH=feature/test
+    out=$(lookup_tags()    { :; }; \
+          lookup_releases(){ :; }; \
+          resolve_main 2>/dev/null)
+    assert_equal "dispatch beta -> release_type=beta"      "beta"            "$(echo "$out" | grep '^release_type='  | cut -d= -f2)"
+    assert_equal "dispatch beta -> source_branch=develop"  "develop"         "$(echo "$out" | grep '^source_branch=' | cut -d= -f2)"
+    assert_equal "dispatch beta -> tag=v9.2.0-beta.1"      "v9.2.0-beta.1"   "$(echo "$out" | grep '^release_tag='   | cut -d= -f2)"
+
+    # workflow_dispatch alpha with source_branch.
+    export GITHUB_EVENT_NAME=workflow_dispatch \
+        INPUT_RELEASE_TYPE=alpha INPUT_SOURCE_BRANCH=feature/foo
+    out=$(lookup_tags()    { :; }; \
+          lookup_releases(){ :; }; \
+          resolve_main 2>/dev/null)
+    assert_equal "dispatch alpha source_branch passes through" "feature/foo" \
+        "$(echo "$out" | grep '^source_branch=' | cut -d= -f2)"
+
+    # push v9.2.0 -> release.
+    export GITHUB_EVENT_NAME=push GITHUB_REF_NAME=v9.2.0 \
+        INPUT_RELEASE_TYPE="" INPUT_SOURCE_BRANCH=""
+    out=$(lookup_tags()    { :; }; \
+          lookup_releases(){ :; }; \
+          resolve_main 2>/dev/null)
+    assert_equal "push v9.2.0 -> release_type=beta"   "beta"     "$(echo "$out" | grep '^release_type='  | cut -d= -f2)"
+    assert_equal "push v9.2.0 -> prerelease=false"    "false"    "$(echo "$out" | grep '^prerelease='    | cut -d= -f2)"
+    assert_equal "push v9.2.0 -> make_latest=true"    "true"     "$(echo "$out" | grep '^make_latest='   | cut -d= -f2)"
+    assert_equal "push v9.2.0 -> tag=v9.2.0"          "v9.2.0"   "$(echo "$out" | grep '^release_tag='   | cut -d= -f2)"
+    assert_equal "push v9.2.0 -> msi_patch=0"         "0"        "$(echo "$out" | grep '^msi_patch_version=' | cut -d= -f2)"
+
+    # push v9.2.5 -> patch carried through.
+    export GITHUB_EVENT_NAME=push GITHUB_REF_NAME=v9.2.5
+    out=$(lookup_tags()    { :; }; \
+          lookup_releases(){ :; }; \
+          resolve_main 2>/dev/null)
+    assert_equal "push v9.2.5 -> msi_patch=5"         "5"        "$(echo "$out" | grep '^msi_patch_version=' | cut -d= -f2)"
+
+    # workflow_dispatch beta -> msi_patch equals the counter.
+    export GITHUB_EVENT_NAME=workflow_dispatch GITHUB_REF_NAME=develop \
+        INPUT_RELEASE_TYPE=beta INPUT_SOURCE_BRANCH=""
+    out=$(lookup_tags()    { printf '%s\n' "v9.2.0-beta.1" "v9.2.0-beta.2"; }; \
+          lookup_releases(){ :; }; \
+          resolve_main 2>/dev/null)
+    assert_equal "beta dispatch -> msi_patch=3 (next counter)" "3" \
+        "$(echo "$out" | grep '^msi_patch_version=' | cut -d= -f2)"
+
+    # workflow_dispatch alpha -> msi_patch empty (Build-Installer.ps1 defaults to yyMMdd).
+    export GITHUB_EVENT_NAME=workflow_dispatch INPUT_RELEASE_TYPE=alpha
+    out=$(lookup_tags()    { :; }; \
+          lookup_releases(){ :; }; \
+          resolve_main 2>/dev/null)
+    assert_equal "alpha dispatch -> msi_patch empty" "" \
+        "$(echo "$out" | grep '^msi_patch_version=' | cut -d= -f2)"
+
+    # push v9.2.0 when already-published -> rule 4 fires.
+    export GITHUB_EVENT_NAME=push GITHUB_REF_NAME=v9.2.0 \
+        INPUT_RELEASE_TYPE="" INPUT_SOURCE_BRANCH=""
+    out=$(lookup_tags()    { :; }; \
+          lookup_releases(){ printf '%s\n' "v9.2.0"; }; \
+          resolve_main 2>&1 >/dev/null; echo "exit=$?")
+    case "$out" in
+        *"already been released"*"exit=2") assert_equal "rule 4 trips on push of published tag" "ok" "ok" ;;
+        *) assert_equal "rule 4 trips on push of published tag" "ok" "got: $out" ;;
+    esac
+
+    # schedule when v9.2.0 already shipped -> rule 3 fires.
+    export GITHUB_EVENT_NAME=schedule GITHUB_REF_NAME=develop \
+        INPUT_RELEASE_TYPE="" INPUT_SOURCE_BRANCH=""
+    out=$(lookup_tags()    { :; }; \
+          lookup_releases(){ printf '%s\n' "v9.2.0"; }; \
+          resolve_main 2>&1 >/dev/null; echo "exit=$?")
+    case "$out" in
+        *"already been released"*"exit=2") assert_equal "rule 3 trips on alpha when v9.2.0 shipped" "ok" "ok" ;;
+        *) assert_equal "rule 3 trips on alpha when v9.2.0 shipped" "ok" "got: $out" ;;
+    esac
+
+    rm -f "$wixproj_tmp"
+    unset WIXPROJ_PATH TODAY_OVERRIDE GITHUB_EVENT_NAME GITHUB_REF_NAME INPUT_RELEASE_TYPE INPUT_SOURCE_BRANCH
+
+    echo
+    echo "Results: $pass passed, $fail failed"
+    [ "$fail" -eq 0 ]
+}
+
+if [ "${1:-}" = "--self-test" ]; then
+    self_test
+    exit $?
+fi
+
+resolve_main

--- a/scripts/resolve-release-tag.sh
+++ b/scripts/resolve-release-tag.sh
@@ -152,6 +152,17 @@ assert_release_not_already_published() {
     fi
 }
 
+# Conflict rule 6: beta dispatches must build from develop. The silent
+# override in earlier versions was a UX bug. The user's source_branch input
+# was discarded with no signal. Fail fast instead so the user notices.
+assert_beta_source_branch_is_develop() {
+    local in_branch="$1"
+    if [ -n "$in_branch" ] && [ "$in_branch" != "develop" ]; then
+        err "Beta dispatches must build from develop. Got source_branch='$in_branch'. Re-dispatch with source_branch=develop (or leave it empty), or use release_type=alpha to build from '$in_branch'."
+        return 2
+    fi
+}
+
 # Top-level orchestrator. Reads workflow context from env, computes the
 # tag and outputs, runs conflict-prevention rules. Writes KEY=VALUE pairs
 # to stdout (intended to be appended to $GITHUB_OUTPUT).
@@ -190,6 +201,7 @@ resolve_main() {
                     # msi_patch_version="" — Build-Installer.ps1 defaults to yyMMdd.
                     ;;
                 beta)
+                    assert_beta_source_branch_is_develop "$in_branch" || return 2
                     # Beta dispatch always builds from develop regardless of input.
                     source_branch=develop
                     assert_no_shipped_release_for "$wix_m" "$wix_n" || return 2
@@ -414,7 +426,7 @@ EOF
 
     # workflow_dispatch beta -> beta-pre-release.
     export GITHUB_EVENT_NAME=workflow_dispatch GITHUB_REF_NAME=develop \
-        INPUT_RELEASE_TYPE=beta INPUT_SOURCE_BRANCH=feature/test
+        INPUT_RELEASE_TYPE=beta INPUT_SOURCE_BRANCH=develop
     out=$(lookup_tags()    { :; }; \
           lookup_releases(){ :; }; \
           resolve_main 2>/dev/null)
@@ -488,6 +500,35 @@ EOF
         *"already been released"*"exit=2") assert_equal "rule 3 trips on alpha when v9.2.0 shipped" "ok" "ok" ;;
         *) assert_equal "rule 3 trips on alpha when v9.2.0 shipped" "ok" "got: $out" ;;
     esac
+
+    # Rule 6: beta dispatch with feature branch -> exit 2
+    export GITHUB_EVENT_NAME=workflow_dispatch GITHUB_REF_NAME=develop \
+        INPUT_RELEASE_TYPE=beta INPUT_SOURCE_BRANCH=feature/X
+    out=$(lookup_tags()    { :; }; \
+          lookup_releases(){ :; }; \
+          resolve_main 2>&1 >/dev/null; echo "exit=$?")
+    case "$out" in
+        *"Beta dispatches must build from develop"*"exit=2") assert_equal "rule 6: beta + feature/X fails" "ok" "ok" ;;
+        *) assert_equal "rule 6: beta + feature/X fails" "ok" "got: $out" ;;
+    esac
+
+    # Rule 6: beta dispatch with main -> exit 2
+    export INPUT_SOURCE_BRANCH=main
+    out=$(lookup_tags()    { :; }; \
+          lookup_releases(){ :; }; \
+          resolve_main 2>&1 >/dev/null; echo "exit=$?")
+    case "$out" in
+        *"Beta dispatches must build from develop"*"exit=2") assert_equal "rule 6: beta + main fails" "ok" "ok" ;;
+        *) assert_equal "rule 6: beta + main fails" "ok" "got: $out" ;;
+    esac
+
+    # Rule 6: beta dispatch with empty source_branch -> succeeds
+    export INPUT_SOURCE_BRANCH=""
+    out=$(lookup_tags()    { :; }; \
+          lookup_releases(){ :; }; \
+          resolve_main 2>/dev/null)
+    assert_equal "rule 6: beta + empty source_branch succeeds" "beta" \
+        "$(echo "$out" | grep '^release_type=' | cut -d= -f2)"
 
     rm -f "$wixproj_tmp"
     unset WIXPROJ_PATH TODAY_OVERRIDE GITHUB_EVENT_NAME GITHUB_REF_NAME INPUT_RELEASE_TYPE INPUT_SOURCE_BRANCH


### PR DESCRIPTION
## Summary

- New `scripts/find-previous-release.sh` selects the diff anchor using SemVer rules. Pre-releases anchor against the most recent stable below the current `M.N`. Patches anchor against `v{M}.{N}.0` of the same line.
- `scripts/compose-release-body.sh` gains three render branches: canonical, baseline, and non-canonical (`source_branch != develop`).
- `scripts/resolve-release-tag.sh` adds rule 6: beta dispatches with a non-develop `source_branch` now hard-fail instead of silently dropping the input.
- `scripts/generate_release_notes.py` accepts an optional `anchor_tag` 4th argv that drives the `### Changes since {anchor_tag}` heading.
- Workflow YAML wires the new step in and conditionally skips the diff section for non-canonical builds.

## Motivation

The current "most recent prior release of any flavour" anchor produces inconsistent narratives. When a beta is dispatched between two alpha nightlies, the next alpha anchors against the beta and skips over the previous alpha. Switching to cumulative-since-stable matches the model the legacy DevOps_Toolkit has always used (PreviousReleaseDate in DevelopToMainPRCommand) and answers a more useful question for installer readers: "what does this build give me compared to the last stable release I had?"

## Spec and plan

- Spec: `docs/superpowers/specs/2026-06-09-installer-changelog-cumulative-since-stable-design.md`
- Plan: `docs/superpowers/plans/2026-06-09-installer-changelog-cumulative-since-stable.md`

## Test plan

- [x] `bash scripts/find-previous-release.sh --self-test` (13 cases passing)
- [x] `bash scripts/resolve-release-tag.sh --self-test` (43 cases passing: existing 40 plus 3 new rule-6 assertions; 1 existing test modified for the success path)
- [x] Local smoke-test of `compose-release-body.sh` in both canonical and non-canonical render branches
- [ ] Live verification on sandbox after merge per Task 11 in the plan: synthetic `v9.1.0` baseline, alpha+develop dispatch, alpha+main dispatch, beta+develop dispatch, beta+feature/X dispatch (rule 6), next nightly auto-fire